### PR TITLE
Clean Code for ant/org.eclipse.ant.core

### DIFF
--- a/.github/workflows/cc2.yml
+++ b/.github/workflows/cc2.yml
@@ -1,0 +1,17 @@
+name: Perform Code Clean 2
+concurrency: 
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+on:
+  workflow_dispatch:
+
+jobs:
+  clean-code:
+    uses: laeubi/eclipse.platform.releng.aggregator/.github/workflows/cleanCode.yml@limit_number_of_cleanup_prs
+    with:
+      author: Eclipse Platform Bot <platform-bot@eclipse.org>
+      do-quickfix: false
+      do-cleanups: true
+      bundle-folders: ant/*/ debug/*/ resources/bundles/*/ runtime/bundles/*/ team/bundles/*/ ua/*/ update/*/ platform/*/
+    secrets:
+      token: ${{ secrets.PLATFORM_BOT_PAT }}

--- a/.github/workflows/cc3.yml
+++ b/.github/workflows/cc3.yml
@@ -1,0 +1,17 @@
+name: Perform Code Clean 3
+concurrency: 
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+on:
+  workflow_dispatch:
+
+jobs:
+  clean-code:
+    uses: laeubi/eclipse.platform.releng.aggregator/.github/workflows/cleanCode.yml@limit_number_of_cleanup_prs
+    with:
+      author: Eclipse Platform Bot <platform-bot@eclipse.org>
+      do-quickfix: false
+      do-cleanups: true
+      bundle-folders: ant/*/ debug/*/ resources/bundles/*/ runtime/bundles/*/ team/bundles/*/ ua/*/ update/*/ platform/*/
+    secrets:
+      token: ${{ secrets.PLATFORM_BOT_PAT }}

--- a/.github/workflows/doCleanCode.yml
+++ b/.github/workflows/doCleanCode.yml
@@ -1,0 +1,17 @@
+name: Perform Code Clean
+concurrency: 
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+on:
+  workflow_dispatch:
+
+jobs:
+  clean-code:
+    uses: laeubi/eclipse.platform.releng.aggregator/.github/workflows/cleanCode.yml@limit_number_of_cleanup_prs
+    with:
+      author: Eclipse Platform Bot <platform-bot@eclipse.org>
+      do-quickfix: false
+      do-cleanups: true
+      bundle-folders: ant/*/ debug/*/ resources/bundles/*/ runtime/bundles/*/ team/bundles/*/ ua/*/ update/*/ platform/*/
+    secrets:
+      token: ${{ secrets.PLATFORM_BOT_PAT }}

--- a/ant/org.eclipse.ant.core/src/org/eclipse/ant/core/AntCorePreferences.java
+++ b/ant/org.eclipse.ant.core/src/org/eclipse/ant/core/AntCorePreferences.java
@@ -663,8 +663,9 @@ public class AntCorePreferences implements IPropertyChangeListener {
 			}
 		}
 
-		if (urlFile == null || !urlFile.exists())
+		if (urlFile == null || !urlFile.exists()) {
 			return null;
+		}
 
 		String path = urlFile.getAbsolutePath();
 		return new URL(IAntCoreConstants.FILE_PROTOCOL + (urlFile.isDirectory() ? path + "/" : path)); //$NON-NLS-1$
@@ -1231,11 +1232,12 @@ public class AntCorePreferences implements IPropertyChangeListener {
 			BundleRevision from = mapping.from;
 			Integer fromCount = counts.get(from);
 			BundleRevision to = mapping.to;
-			if (to == null)
+			if (to == null) {
 				counts.put(from, Integer.valueOf(0));
-			else {
-				if (counts.get(to) == null)
+			} else {
+				if (counts.get(to) == null) {
 					counts.put(to, Integer.valueOf(0));
+				}
 				fromCount = fromCount == null ? Integer.valueOf(1) : Integer.valueOf(fromCount.intValue() + 1);
 				counts.put(from, fromCount);
 			}

--- a/ant/org.eclipse.ant.core/src/org/eclipse/ant/core/AntRunner.java
+++ b/ant/org.eclipse.ant.core/src/org/eclipse/ant/core/AntRunner.java
@@ -140,8 +140,9 @@ public class AntRunner implements IApplication {
 					}
 					waitingForQuote = true;
 				} else {
-					if (!(token.equals(",") || token.equals(" "))) //$NON-NLS-1$ //$NON-NLS-2$
+					if (!(token.equals(",") || token.equals(" "))) { //$NON-NLS-1$ //$NON-NLS-2$
 						result.add(token);
+					}
 				}
 			}
 		}
@@ -281,7 +282,7 @@ public class AntRunner implements IApplication {
 		setProperties(runner, classInternalAntRunner);
 
 		if (arguments != null && arguments.length > 0) {
-			Method setArguments = classInternalAntRunner.getMethod("setArguments", new Class[] { String[].class }); //$NON-NLS-1$
+			Method setArguments = classInternalAntRunner.getMethod("setArguments", String[].class); //$NON-NLS-1$
 			setArguments.invoke(runner, new Object[] { arguments });
 		}
 	}
@@ -319,7 +320,7 @@ public class AntRunner implements IApplication {
 
 			// set the custom classpath
 			if (customClasspath != null) {
-				Method setCustomClasspath = classInternalAntRunner.getMethod("setCustomClasspath", new Class[] { URL[].class }); //$NON-NLS-1$
+				Method setCustomClasspath = classInternalAntRunner.getMethod("setCustomClasspath", URL[].class); //$NON-NLS-1$
 				setCustomClasspath.invoke(runner, new Object[] { customClasspath });
 			}
 
@@ -360,7 +361,7 @@ public class AntRunner implements IApplication {
 
 			// set execution targets
 			if (targets != null) {
-				Method setExecutionTargets = classInternalAntRunner.getMethod("setExecutionTargets", new Class[] { String[].class }); //$NON-NLS-1$
+				Method setExecutionTargets = classInternalAntRunner.getMethod("setExecutionTargets", String[].class); //$NON-NLS-1$
 				setExecutionTargets.invoke(runner, new Object[] { targets });
 			}
 
@@ -400,7 +401,7 @@ public class AntRunner implements IApplication {
 
 		// add property files
 		if (propertyFiles != null) {
-			Method addPropertyFiles = classInternalAntRunner.getMethod("addPropertyFiles", new Class[] { String[].class }); //$NON-NLS-1$
+			Method addPropertyFiles = classInternalAntRunner.getMethod("addPropertyFiles", String[].class); //$NON-NLS-1$
 			addPropertyFiles.invoke(runner, new Object[] { propertyFiles });
 		}
 	}

--- a/ant/org.eclipse.ant.core/src/org/eclipse/ant/core/TargetInfo.java
+++ b/ant/org.eclipse.ant.core/src/org/eclipse/ant/core/TargetInfo.java
@@ -100,10 +100,9 @@ public class TargetInfo {
 
 	@Override
 	public boolean equals(Object obj) {
-		if (!(obj instanceof TargetInfo)) {
+		if (!(obj instanceof TargetInfo other)) {
 			return false;
 		}
-		TargetInfo other = (TargetInfo) obj;
 		return getName().equals(other.getName());
 	}
 

--- a/ant/org.eclipse.ant.core/src/org/eclipse/ant/internal/core/AntClasspathEntry.java
+++ b/ant/org.eclipse.ant.core/src/org/eclipse/ant/internal/core/AntClasspathEntry.java
@@ -80,8 +80,7 @@ public class AntClasspathEntry implements IAntClasspathEntry {
 
 	@Override
 	public boolean equals(Object obj) {
-		if (obj instanceof IAntClasspathEntry) {
-			IAntClasspathEntry other = (IAntClasspathEntry) obj;
+		if (obj instanceof IAntClasspathEntry other) {
 			return entryString.equals(other.getLabel());
 		}
 		return false;

--- a/ant/org.eclipse.ant.core/src_ant/org/eclipse/ant/internal/core/ant/InputHandlerSetter.java
+++ b/ant/org.eclipse.ant.core/src_ant/org/eclipse/ant/internal/core/ant/InputHandlerSetter.java
@@ -35,13 +35,11 @@ class InputHandlerSetter {
 				handler = (InputHandler) (Class.forName(inputHandlerClassname).getConstructor().newInstance());
 			}
 			catch (ClassCastException e) {
-				String msg = MessageFormat.format(InternalAntMessages.InternalAntRunner_handler_does_not_implement_InputHandler5, new Object[] {
-						inputHandlerClassname });
+				String msg = MessageFormat.format(InternalAntMessages.InternalAntRunner_handler_does_not_implement_InputHandler5, inputHandlerClassname);
 				throw new BuildException(msg, e);
 			}
 			catch (Exception e) {
-				String msg = MessageFormat.format(InternalAntMessages.InternalAntRunner_Unable_to_instantiate_input_handler_class, new Object[] {
-						inputHandlerClassname, e.getClass().getName() });
+				String msg = MessageFormat.format(InternalAntMessages.InternalAntRunner_Unable_to_instantiate_input_handler_class, inputHandlerClassname, e.getClass().getName());
 				throw new BuildException(msg, e);
 			}
 		}

--- a/ant/org.eclipse.ant.core/src_ant/org/eclipse/ant/internal/core/ant/InternalAntRunner.java
+++ b/ant/org.eclipse.ant.core/src_ant/org/eclipse/ant/internal/core/ant/InternalAntRunner.java
@@ -253,8 +253,7 @@ public class InternalAntRunner {
 			}
 		}
 		catch (ClassCastException e) {
-			String message = MessageFormat.format(InternalAntMessages.InternalAntRunner_not_an_instance_of_apache_ant_BuildListener, new Object[] {
-					className });
+			String message = MessageFormat.format(InternalAntMessages.InternalAntRunner_not_an_instance_of_apache_ant_BuildListener, className);
 			if (log) {
 				logMessage(null, message, Project.MSG_ERR);
 			}
@@ -281,8 +280,9 @@ public class InternalAntRunner {
 						// do nothing
 					}
 				}
-				if (value != null)
+				if (value != null) {
 					project.setUserProperty(entry.getKey(), value);
+				}
 			}
 			// may have properties set (always have the Ant process ID)
 			// using the Arguments and not the Properties page
@@ -337,8 +337,7 @@ public class InternalAntRunner {
 							project.checkTaskClass(taskClass);
 						}
 						catch (BuildException e) {
-							IStatus status = new Status(IStatus.ERROR, AntCorePlugin.PI_ANTCORE, AntCorePlugin.ERROR_RUNNING_BUILD, MessageFormat.format(InternalAntMessages.InternalAntRunner_Error_setting_Ant_task, new Object[] {
-									task.getTaskName() }), e);
+							IStatus status = new Status(IStatus.ERROR, AntCorePlugin.PI_ANTCORE, AntCorePlugin.ERROR_RUNNING_BUILD, MessageFormat.format(InternalAntMessages.InternalAntRunner_Error_setting_Ant_task, task.getTaskName()), e);
 							AntCorePlugin.getPlugin().getLog().log(status);
 							continue;
 						}
@@ -346,8 +345,7 @@ public class InternalAntRunner {
 					project.addTaskDefinition(task.getTaskName(), taskClass);
 				}
 				catch (ClassNotFoundException e) {
-					IStatus status = new Status(IStatus.ERROR, AntCorePlugin.PI_ANTCORE, AntCorePlugin.ERROR_RUNNING_BUILD, MessageFormat.format(InternalAntMessages.InternalAntRunner_Class_not_found_for_task, new Object[] {
-							task.getClassName(), task.getTaskName() }), e);
+					IStatus status = new Status(IStatus.ERROR, AntCorePlugin.PI_ANTCORE, AntCorePlugin.ERROR_RUNNING_BUILD, MessageFormat.format(InternalAntMessages.InternalAntRunner_Class_not_found_for_task, task.getClassName(), task.getTaskName()), e);
 					AntCorePlugin.getPlugin().getLog().log(status);
 				}
 			}
@@ -369,8 +367,7 @@ public class InternalAntRunner {
 					project.addDataTypeDefinition(type.getTypeName(), typeClass);
 				}
 				catch (ClassNotFoundException e) {
-					IStatus status = new Status(IStatus.ERROR, AntCorePlugin.PI_ANTCORE, AntCorePlugin.ERROR_RUNNING_BUILD, MessageFormat.format(InternalAntMessages.InternalAntRunner_Class_not_found_for_type, new Object[] {
-							type.getClassName(), type.getTypeName() }), e);
+					IStatus status = new Status(IStatus.ERROR, AntCorePlugin.PI_ANTCORE, AntCorePlugin.ERROR_RUNNING_BUILD, MessageFormat.format(InternalAntMessages.InternalAntRunner_Class_not_found_for_type, type.getClassName(), type.getTypeName()), e);
 					AntCorePlugin.getPlugin().getLog().log(status);
 				}
 			}
@@ -386,12 +383,10 @@ public class InternalAntRunner {
 	protected void parseBuildFile(Project project) {
 		File buildFile = new File(getBuildFileLocation());
 		if (!buildFile.exists()) {
-			throw new BuildException(MessageFormat.format(InternalAntMessages.InternalAntRunner_Buildfile_does_not_exist, new Object[] {
-					buildFile.getAbsolutePath() }));
+			throw new BuildException(MessageFormat.format(InternalAntMessages.InternalAntRunner_Buildfile_does_not_exist, buildFile.getAbsolutePath()));
 		}
 		if (!buildFile.isFile()) {
-			throw new BuildException(MessageFormat.format(InternalAntMessages.InternalAntRunner_Buildfile_is_not_a_file, new Object[] {
-					buildFile.getAbsolutePath() }));
+			throw new BuildException(MessageFormat.format(InternalAntMessages.InternalAntRunner_Buildfile_is_not_a_file, buildFile.getAbsolutePath()));
 		}
 
 		if (!isVersionCompatible("1.5")) { //$NON-NLS-1$
@@ -463,8 +458,8 @@ public class InternalAntRunner {
 			}
 			if (!defaultFound) {
 				// default target must exist
-				throw new BuildException(MessageFormat.format(InternalAntMessages.InternalAntRunner_Default_target_does_not_exist, new Object[] { "'", //$NON-NLS-1$
-						defaultTarget, "'" })); //$NON-NLS-1$
+				throw new BuildException(MessageFormat.format(InternalAntMessages.InternalAntRunner_Default_target_does_not_exist, "'", //$NON-NLS-1$
+										defaultTarget, "'")); //$NON-NLS-1$
 			}
 			return infos;
 		}
@@ -551,7 +546,7 @@ public class InternalAntRunner {
 			sb.append(extraArgument);
 			sb.append(' ');
 		}
-		project.log(MessageFormat.format(InternalAntMessages.InternalAntRunner_Arguments, new Object[] { sb.toString().trim() }));
+		project.log(MessageFormat.format(InternalAntMessages.InternalAntRunner_Arguments, sb.toString().trim()));
 	}
 
 	private void createMonitorBuildListener(Project project) {
@@ -680,8 +675,7 @@ public class InternalAntRunner {
 			}
 
 			if (!projectHelp) {
-				logMessage(currentProject, MessageFormat.format(InternalAntMessages.InternalAntRunner_Build_file, new Object[] {
-						getBuildFileLocation() }), Project.MSG_INFO);
+				logMessage(currentProject, MessageFormat.format(InternalAntMessages.InternalAntRunner_Build_file, getBuildFileLocation()), Project.MSG_INFO);
 
 				setTasks(getCurrentProject());
 				setTypes(getCurrentProject());
@@ -814,14 +808,12 @@ public class InternalAntRunner {
 				buildLogger = (BuildLogger) (Class.forName(loggerClassname).getConstructor().newInstance());
 			}
 			catch (ClassCastException e) {
-				String message = MessageFormat.format(InternalAntMessages.InternalAntRunner_not_an_instance_of_apache_ant_BuildLogger, new Object[] {
-						loggerClassname });
+				String message = MessageFormat.format(InternalAntMessages.InternalAntRunner_not_an_instance_of_apache_ant_BuildLogger, loggerClassname);
 				logMessage(null, message, Project.MSG_ERR);
 				throw new BuildException(message, e);
 			}
 			catch (Exception e) {
-				String message = MessageFormat.format(InternalAntMessages.InternalAntRunner_Unable_to_instantiate_logger, new Object[] {
-						loggerClassname });
+				String message = MessageFormat.format(InternalAntMessages.InternalAntRunner_Unable_to_instantiate_logger, loggerClassname);
 				logMessage(null, message, Project.MSG_ERR);
 				throw new BuildException(message, e);
 			}
@@ -1011,12 +1003,10 @@ public class InternalAntRunner {
 				antVersionNumber = versionNumber;
 			}
 			catch (IOException ioe) {
-				throw new BuildException(MessageFormat.format(InternalAntMessages.InternalAntRunner_Could_not_load_the_version_information, new Object[] {
-						ioe.getMessage() }), ioe);
+				throw new BuildException(MessageFormat.format(InternalAntMessages.InternalAntRunner_Could_not_load_the_version_information, ioe.getMessage()), ioe);
 			}
 			catch (NullPointerException npe) {
-				throw new BuildException(MessageFormat.format(InternalAntMessages.InternalAntRunner_Could_not_load_the_version_information, new Object[] {
-						npe.getMessage() }), npe);
+				throw new BuildException(MessageFormat.format(InternalAntMessages.InternalAntRunner_Could_not_load_the_version_information, npe.getMessage()), npe);
 			}
 		}
 		return antVersionNumber;
@@ -1185,8 +1175,7 @@ public class InternalAntRunner {
 			}
 			catch (IOException e) {
 				// just log message and ignore exception
-				logMessage(currentProject, MessageFormat.format(InternalAntMessages.InternalAntRunner_Could_not_write_to_log_file, new Object[] {
-						arg }), Project.MSG_ERR);
+				logMessage(currentProject, MessageFormat.format(InternalAntMessages.InternalAntRunner_Could_not_write_to_log_file, arg), Project.MSG_ERR);
 				return false;
 			}
 
@@ -1262,7 +1251,7 @@ public class InternalAntRunner {
 			String target = iterator.next();
 			if (!names.contains(target)) {
 				iterator.remove();
-				String message = MessageFormat.format(InternalAntMessages.InternalAntRunner_unknown_target, new Object[] { target });
+				String message = MessageFormat.format(InternalAntMessages.InternalAntRunner_unknown_target, target);
 				logMessage(currentProject, message, Project.MSG_WARN);
 				unknownTargetsFound = true;
 			}
@@ -1296,7 +1285,7 @@ public class InternalAntRunner {
 		}
 
 		// warn of ignored commands
-		String message = MessageFormat.format(InternalAntMessages.InternalAntRunner_Unknown_argument, new Object[] { s.substring(1) });
+		String message = MessageFormat.format(InternalAntMessages.InternalAntRunner_Unknown_argument, s.substring(1));
 		logMessage(currentProject, message, Project.MSG_WARN);
 	}
 
@@ -1321,8 +1310,7 @@ public class InternalAntRunner {
 		// this stream is closed in the finally block of run(list)
 		out = new PrintStream(new FileOutputStream(logFile));
 		err = out;
-		logMessage(currentProject, MessageFormat.format(InternalAntMessages.InternalAntRunner_Using_file_as_build_log, new Object[] {
-				logFile.getCanonicalPath() }), Project.MSG_INFO);
+		logMessage(currentProject, MessageFormat.format(InternalAntMessages.InternalAntRunner_Using_file_as_build_log, logFile.getCanonicalPath()), Project.MSG_INFO);
 		if (buildLogger != null) {
 			buildLogger.setErrorPrintStream(err);
 			buildLogger.setOutputPrintStream(out);
@@ -1456,8 +1444,7 @@ public class InternalAntRunner {
 			}
 		}
 		catch (IOException e) {
-			fEarlyErrorMessage = MessageFormat.format(InternalAntMessages.InternalAntRunner_could_not_load_property_file, new Object[] {
-					e.getMessage() });
+			fEarlyErrorMessage = MessageFormat.format(InternalAntMessages.InternalAntRunner_could_not_load_property_file, e.getMessage());
 		}
 	}
 

--- a/ant/org.eclipse.ant.core/src_ant/org/eclipse/ant/internal/core/ant/InternalProject.java
+++ b/ant/org.eclipse.ant.core/src_ant/org/eclipse/ant/internal/core/ant/InternalProject.java
@@ -85,19 +85,19 @@ public class InternalProject extends Project {
 			// DataType can have a "no arg" constructor or take a single
 			// Project argument.
 			try {
-				ctor = typeClass.getConstructor(new Class[0]);
+				ctor = typeClass.getConstructor();
 				noArg = true;
 			}
 			catch (NoSuchMethodException nse) {
-				ctor = typeClass.getConstructor(new Class[] { Project.class });
+				ctor = typeClass.getConstructor(Project.class);
 				noArg = false;
 			}
 
 			Object o = null;
 			if (noArg) {
-				o = ctor.newInstance(new Object[0]);
+				o = ctor.newInstance();
 			} else {
-				o = ctor.newInstance(new Object[] { this });
+				o = ctor.newInstance(this);
 			}
 			if (o instanceof ProjectComponent) {
 				((ProjectComponent) o).setProject(this);
@@ -123,8 +123,7 @@ public class InternalProject extends Project {
 			thrown = ncdfe;
 		}
 		if (thrown != null) {
-			String message = MessageFormat.format(InternalAntMessages.InternalProject_could_not_create_type, new Object[] { typeName,
-					thrown.toString() });
+			String message = MessageFormat.format(InternalAntMessages.InternalProject_could_not_create_type, typeName, thrown.toString());
 			throw new BuildException(message, thrown);
 		}
 		// this line is actually unreachable


### PR DESCRIPTION
### The following cleanups where applied:

- Add final modifier to private fields
- Add missing '<span>@</span>Deprecated' annotations
- Add missing '<span>@</span>Override' annotations
- Add missing '<span>@</span>Override' annotations to implementations of interface methods
- Convert control statement bodies to block
- Make inner classes static where possible
- Remove unnecessary array creation for varargs
- Remove unnecessary suppress warning tokens
- Replace deprecated calls with inlined content where possible
- Use pattern matching for instanceof

