### PR TITLE
Clean Code for ant/org.eclipse.ant.launching

### DIFF
--- a/.github/workflows/cc2.yml
+++ b/.github/workflows/cc2.yml
@@ -1,0 +1,17 @@
+name: Perform Code Clean 2
+concurrency: 
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+on:
+  workflow_dispatch:
+
+jobs:
+  clean-code:
+    uses: laeubi/eclipse.platform.releng.aggregator/.github/workflows/cleanCode.yml@limit_number_of_cleanup_prs
+    with:
+      author: Eclipse Platform Bot <platform-bot@eclipse.org>
+      do-quickfix: false
+      do-cleanups: true
+      bundle-folders: ant/*/ debug/*/ resources/bundles/*/ runtime/bundles/*/ team/bundles/*/ ua/*/ update/*/ platform/*/
+    secrets:
+      token: ${{ secrets.PLATFORM_BOT_PAT }}

--- a/.github/workflows/cc3.yml
+++ b/.github/workflows/cc3.yml
@@ -1,0 +1,17 @@
+name: Perform Code Clean 3
+concurrency: 
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+on:
+  workflow_dispatch:
+
+jobs:
+  clean-code:
+    uses: laeubi/eclipse.platform.releng.aggregator/.github/workflows/cleanCode.yml@limit_number_of_cleanup_prs
+    with:
+      author: Eclipse Platform Bot <platform-bot@eclipse.org>
+      do-quickfix: false
+      do-cleanups: true
+      bundle-folders: ant/*/ debug/*/ resources/bundles/*/ runtime/bundles/*/ team/bundles/*/ ua/*/ update/*/ platform/*/
+    secrets:
+      token: ${{ secrets.PLATFORM_BOT_PAT }}

--- a/.github/workflows/doCleanCode.yml
+++ b/.github/workflows/doCleanCode.yml
@@ -1,0 +1,17 @@
+name: Perform Code Clean
+concurrency: 
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+on:
+  workflow_dispatch:
+
+jobs:
+  clean-code:
+    uses: laeubi/eclipse.platform.releng.aggregator/.github/workflows/cleanCode.yml@limit_number_of_cleanup_prs
+    with:
+      author: Eclipse Platform Bot <platform-bot@eclipse.org>
+      do-quickfix: false
+      do-cleanups: true
+      bundle-folders: ant/*/ debug/*/ resources/bundles/*/ runtime/bundles/*/ team/bundles/*/ ua/*/ update/*/ platform/*/
+    secrets:
+      token: ${{ secrets.PLATFORM_BOT_PAT }}

--- a/ant/org.eclipse.ant.launching/remote/org/eclipse/ant/internal/launching/remote/InputHandlerSetter.java
+++ b/ant/org.eclipse.ant.launching/remote/org/eclipse/ant/internal/launching/remote/InputHandlerSetter.java
@@ -35,13 +35,11 @@ class InputHandlerSetter {
 				handler = (InputHandler) (Class.forName(inputHandlerClassname).getConstructor().newInstance());
 			}
 			catch (ClassCastException e) {
-				String msg = MessageFormat.format(RemoteAntMessages.getString("InternalAntRunner.The_specified_input_handler_class_{0}_does_not_implement_the_org.apache.tools.ant.input.InputHandler_interface_5"), new Object[] { //$NON-NLS-1$
-						inputHandlerClassname });
+				String msg = MessageFormat.format(RemoteAntMessages.getString("InternalAntRunner.The_specified_input_handler_class_{0}_does_not_implement_the_org.apache.tools.ant.input.InputHandler_interface_5"), inputHandlerClassname);
 				throw new BuildException(msg, e);
 			}
 			catch (Exception e) {
-				String msg = MessageFormat.format(RemoteAntMessages.getString("InternalAntRunner.Unable_to_instantiate_specified_input_handler_class_{0}___{1}_6"), new Object[] { //$NON-NLS-1$
-						inputHandlerClassname, e.getClass().getName() });
+				String msg = MessageFormat.format(RemoteAntMessages.getString("InternalAntRunner.Unable_to_instantiate_specified_input_handler_class_{0}___{1}_6"), inputHandlerClassname, e.getClass().getName());
 				throw new BuildException(msg, e);
 			}
 		}

--- a/ant/org.eclipse.ant.launching/remote/org/eclipse/ant/internal/launching/remote/InternalAntRunner.java
+++ b/ant/org.eclipse.ant.launching/remote/org/eclipse/ant/internal/launching/remote/InternalAntRunner.java
@@ -192,8 +192,7 @@ public class InternalAntRunner {
 			}
 		}
 		catch (ClassCastException e) {
-			String message = MessageFormat.format(RemoteAntMessages.getString("InternalAntRunner.{0}_which_was_specified_to_be_a_build_listener_is_not_an_instance_of_org.apache.tools.ant.BuildListener._1"), new Object[] { //$NON-NLS-1$
-					clazz });
+			String message = MessageFormat.format(RemoteAntMessages.getString("InternalAntRunner.{0}_which_was_specified_to_be_a_build_listener_is_not_an_instance_of_org.apache.tools.ant.BuildListener._1"), clazz);
 			logMessage(null, message, Project.MSG_ERR);
 			throw new BuildException(message, e);
 		}
@@ -215,11 +214,11 @@ public class InternalAntRunner {
 		File buildFile = new File(getBuildFileLocation());
 		if (!buildFile.exists()) {
 			throw new BuildException(MessageFormat.format(RemoteAntMessages.getString("InternalAntRunner.Buildfile__{0}_does_not_exist_!_1"), //$NON-NLS-1$
-					new Object[] { buildFile.getAbsolutePath() }));
+					buildFile.getAbsolutePath()));
 		}
 		if (!buildFile.isFile()) {
 			throw new BuildException(MessageFormat.format(RemoteAntMessages.getString("InternalAntRunner.Buildfile__{0}_is_not_a_file_1"), //$NON-NLS-1$
-					new Object[] { buildFile.getAbsolutePath() }));
+					buildFile.getAbsolutePath()));
 		}
 
 		if (!isVersionCompatible("1.5")) { //$NON-NLS-1$
@@ -248,7 +247,7 @@ public class InternalAntRunner {
 			sb.append(extraArgument);
 			sb.append(' ');
 		}
-		project.log(MessageFormat.format(RemoteAntMessages.getString("InternalAntRunner.Arguments__{0}_2"), new Object[] { sb.toString().trim() })); //$NON-NLS-1$
+		project.log(MessageFormat.format(RemoteAntMessages.getString("InternalAntRunner.Arguments__{0}_2"), sb.toString().trim())); //$NON-NLS-1$
 	}
 
 	/**
@@ -433,8 +432,7 @@ public class InternalAntRunner {
 				}
 			}
 
-			getCurrentProject().log(MessageFormat.format(RemoteAntMessages.getString("InternalAntRunner.Build_file__{0}_1"), new Object[] { //$NON-NLS-1$
-					getBuildFileLocation() }));
+			getCurrentProject().log(MessageFormat.format(RemoteAntMessages.getString("InternalAntRunner.Build_file__{0}_1"), getBuildFileLocation()));
 
 			setTasks();
 			setTypes();
@@ -523,8 +521,8 @@ public class InternalAntRunner {
 						getCurrentProject().addTaskDefinition(taskName, taskClass);
 					}
 					catch (ClassNotFoundException e) {
-						String message = MessageFormat.format(RemoteAntMessages.getString("InternalAntRunner.161"), new Object[] { taskClassName, //$NON-NLS-1$
-								taskName });
+						String message = MessageFormat.format(RemoteAntMessages.getString("InternalAntRunner.161"), taskClassName, //$NON-NLS-1$
+														taskName);
 						getCurrentProject().log(message, Project.MSG_WARN);
 					}
 				}
@@ -551,8 +549,8 @@ public class InternalAntRunner {
 						getCurrentProject().addDataTypeDefinition(typeName, typeClass);
 					}
 					catch (ClassNotFoundException e) {
-						String message = MessageFormat.format(RemoteAntMessages.getString("InternalAntRunner.162"), new Object[] { typeClassName, //$NON-NLS-1$
-								typeName });
+						String message = MessageFormat.format(RemoteAntMessages.getString("InternalAntRunner.162"), typeClassName, //$NON-NLS-1$
+														typeName);
 						getCurrentProject().log(message, Project.MSG_WARN);
 					}
 				}
@@ -581,14 +579,12 @@ public class InternalAntRunner {
 				buildLogger = (BuildLogger) (Class.forName(loggerClassname).getConstructor().newInstance());
 			}
 			catch (ClassCastException e) {
-				String message = MessageFormat.format(RemoteAntMessages.getString("InternalAntRunner.{0}_which_was_specified_to_perform_logging_is_not_an_instance_of_org.apache.tools.ant.BuildLogger._2"), new Object[] { //$NON-NLS-1$
-						loggerClassname });
+				String message = MessageFormat.format(RemoteAntMessages.getString("InternalAntRunner.{0}_which_was_specified_to_perform_logging_is_not_an_instance_of_org.apache.tools.ant.BuildLogger._2"), loggerClassname);
 				logMessage(null, message, Project.MSG_ERR);
 				throw new BuildException(message, e);
 			}
 			catch (Exception e) {
-				String message = MessageFormat.format(RemoteAntMessages.getString("InternalAntRunner.Unable_to_instantiate_logger__{0}_6"), new Object[] { //$NON-NLS-1$
-						loggerClassname });
+				String message = MessageFormat.format(RemoteAntMessages.getString("InternalAntRunner.Unable_to_instantiate_logger__{0}_6"), loggerClassname);
 				logMessage(null, message, Project.MSG_ERR);
 				throw new BuildException(message, e);
 			}
@@ -688,8 +684,7 @@ public class InternalAntRunner {
 				antVersionNumber = versionNumber;
 			}
 			catch (IOException ioe) {
-				throw new BuildException(MessageFormat.format(RemoteAntMessages.getString("InternalAntRunner.Could_not_load_the_version_information._{0}_9"), new Object[] { //$NON-NLS-1$
-						ioe.getMessage() }), ioe);
+				throw new BuildException(MessageFormat.format(RemoteAntMessages.getString("InternalAntRunner.Could_not_load_the_version_information._{0}_9"), ioe.getMessage()), ioe);
 			}
 			catch (NullPointerException npe) {
 				throw new BuildException(RemoteAntMessages.getString("InternalAntRunner.Could_not_load_the_version_information._10"), npe); //$NON-NLS-1$
@@ -900,8 +895,7 @@ public class InternalAntRunner {
 			}
 			catch (IOException e) {
 				// just log message and ignore exception
-				logMessage(getCurrentProject(), MessageFormat.format(RemoteAntMessages.getString("InternalAntRunner.Could_not_write_to_the_specified_log_file__{0}._Make_sure_the_path_exists_and_you_have_write_permissions._2"), new Object[] { //$NON-NLS-1$
-						arg }), Project.MSG_ERR);
+				logMessage(getCurrentProject(), MessageFormat.format(RemoteAntMessages.getString("InternalAntRunner.Could_not_write_to_the_specified_log_file__{0}._Make_sure_the_path_exists_and_you_have_write_permissions._2"), arg), Project.MSG_ERR);
 				return false;
 			}
 
@@ -1017,8 +1011,7 @@ public class InternalAntRunner {
 		}
 
 		// warn of ignored commands
-		String message = MessageFormat.format(RemoteAntMessages.getString("InternalAntRunner.Unknown_argument__{0}_2"), new Object[] { //$NON-NLS-1$
-				s.substring(1) });
+		String message = MessageFormat.format(RemoteAntMessages.getString("InternalAntRunner.Unknown_argument__{0}_2"), s.substring(1));
 		logMessage(currentProject, message, Project.MSG_WARN);
 	}
 
@@ -1044,8 +1037,7 @@ public class InternalAntRunner {
 		// this stream is closed in the finally block of run(list)
 		out = new PrintStream(new FileOutputStream(logFile));
 		err = out;
-		logMessage(getCurrentProject(), MessageFormat.format(RemoteAntMessages.getString("InternalAntRunner.Using_{0}_file_as_build_log._1"), new Object[] { //$NON-NLS-1$
-				logFile.getCanonicalPath() }), Project.MSG_INFO);
+		logMessage(getCurrentProject(), MessageFormat.format(RemoteAntMessages.getString("InternalAntRunner.Using_{0}_file_as_build_log._1"), logFile.getCanonicalPath()), Project.MSG_INFO);
 		if (buildLogger != null) {
 			buildLogger.setErrorPrintStream(err);
 			buildLogger.setOutputPrintStream(out);
@@ -1132,8 +1124,9 @@ public class InternalAntRunner {
 		setBuiltInProperties(project);
 		if (userProperties != null) {
 			for (Entry<String, String> entry : userProperties.entrySet()) {
-				if (entry.getValue() != null)
+				if (entry.getValue() != null) {
 					project.setUserProperty(entry.getKey(), entry.getValue());
+				}
 			}
 		}
 	}
@@ -1294,8 +1287,7 @@ public class InternalAntRunner {
 				props.load(fis);
 			}
 			catch (IOException e) {
-				fEarlyErrorMessage = MessageFormat.format(RemoteAntMessages.getString("InternalAntRunner.Could_not_load_property_file_{0}__{1}_4"), new Object[] { //$NON-NLS-1$
-						filename, e.getMessage() });
+				fEarlyErrorMessage = MessageFormat.format(RemoteAntMessages.getString("InternalAntRunner.Could_not_load_property_file_{0}__{1}_4"), filename, e.getMessage());
 			}
 			if (userProperties == null) {
 				userProperties = new HashMap<>();

--- a/ant/org.eclipse.ant.launching/remote/org/eclipse/ant/internal/launching/remote/logger/RemoteAntBreakpoint.java
+++ b/ant/org.eclipse.ant.launching/remote/org/eclipse/ant/internal/launching/remote/logger/RemoteAntBreakpoint.java
@@ -47,10 +47,9 @@ public class RemoteAntBreakpoint {
 
 	@Override
 	public boolean equals(Object obj) {
-		if (!(obj instanceof RemoteAntBreakpoint)) {
+		if (!(obj instanceof RemoteAntBreakpoint other)) {
 			return false;
 		}
-		RemoteAntBreakpoint other = (RemoteAntBreakpoint) obj;
 		return other.getLineNumber() == fLineNumber && other.getFile().equals(fFile);
 	}
 

--- a/ant/org.eclipse.ant.launching/src/org/eclipse/ant/internal/launching/AntLaunchingUtil.java
+++ b/ant/org.eclipse.ant.launching/src/org/eclipse/ant/internal/launching/AntLaunchingUtil.java
@@ -73,11 +73,13 @@ public final class AntLaunchingUtil {
 	 * @return a single-string representation of the strings or <code>null</code> if the array is empty.
 	 */
 	public static String combineStrings(String[] strings) {
-		if (strings.length == 0)
+		if (strings.length == 0) {
 			return null;
+		}
 
-		if (strings.length == 1)
+		if (strings.length == 1) {
 			return strings[0];
+		}
 
 		StringBuilder buf = new StringBuilder();
 		for (int i = 0; i < strings.length - 1; i++) {
@@ -231,7 +233,7 @@ public final class AntLaunchingUtil {
 	private static String expandVariableString(String variableString, String invalidMessage) throws CoreException {
 		String expandedString = VariablesPlugin.getDefault().getStringVariableManager().performStringSubstitution(variableString);
 		if (expandedString == null || expandedString.length() == 0) {
-			String msg = MessageFormat.format(invalidMessage, new Object[] { variableString });
+			String msg = MessageFormat.format(invalidMessage, variableString);
 			throw new CoreException(new Status(IStatus.ERROR, AntLaunching.PLUGIN_ID, 0, msg, null));
 		}
 		return expandedString;

--- a/ant/org.eclipse.ant.launching/src/org/eclipse/ant/internal/launching/debug/model/AntLineBreakpoint.java
+++ b/ant/org.eclipse.ant.launching/src/org/eclipse/ant/internal/launching/debug/model/AntLineBreakpoint.java
@@ -76,8 +76,7 @@ public class AntLineBreakpoint extends LineBreakpoint {
 			attributes.put(IBreakpoint.ENABLED, Boolean.TRUE);
 			attributes.put(IMarker.LINE_NUMBER, Integer.valueOf(lineNumber));
 			attributes.put(IBreakpoint.ID, IAntDebugConstants.ID_ANT_DEBUG_MODEL);
-			attributes.put(IMarker.MESSAGE, MessageFormat.format(DebugModelMessages.AntLineBreakpoint_0, new Object[] {
-					Integer.toString(lineNumber) }));
+			attributes.put(IMarker.MESSAGE, MessageFormat.format(DebugModelMessages.AntLineBreakpoint_0, Integer.toString(lineNumber)));
 			ensureMarker().setAttributes(attributes);
 
 			register(register);

--- a/ant/org.eclipse.ant.launching/src/org/eclipse/ant/internal/launching/debug/model/AntStackFrame.java
+++ b/ant/org.eclipse.ant.launching/src/org/eclipse/ant/internal/launching/debug/model/AntStackFrame.java
@@ -206,8 +206,7 @@ public class AntStackFrame extends AntDebugElement implements IStackFrame {
 
 	@Override
 	public boolean equals(Object obj) {
-		if (obj instanceof AntStackFrame) {
-			AntStackFrame sf = (AntStackFrame) obj;
+		if (obj instanceof AntStackFrame sf) {
 			if (getSourceName() != null) {
 				return getSourceName().equals(sf.getSourceName()) && sf.getLineNumber() == getLineNumber() && sf.fId == fId;
 			}

--- a/ant/org.eclipse.ant.launching/src/org/eclipse/ant/internal/launching/launchConfigurations/AntHomeClasspathEntry.java
+++ b/ant/org.eclipse.ant.launching/src/org/eclipse/ant/internal/launching/launchConfigurations/AntHomeClasspathEntry.java
@@ -119,10 +119,10 @@ public class AntHomeClasspathEntry extends AbstractRuntimeClasspathEntry {
 		File lib = libDir.toFile();
 		File parentDir = lib.getParentFile();
 		if (parentDir == null || !parentDir.exists()) {
-			abort(MessageFormat.format(AntLaunchConfigurationMessages.AntHomeClasspathEntry_10, new Object[] { antHomeLocation }), null);
+			abort(MessageFormat.format(AntLaunchConfigurationMessages.AntHomeClasspathEntry_10, antHomeLocation), null);
 		}
 		if (!lib.exists() || !lib.isDirectory()) {
-			abort(MessageFormat.format(AntLaunchConfigurationMessages.AntHomeClasspathEntry_11, new Object[] { antHomeLocation }), null);
+			abort(MessageFormat.format(AntLaunchConfigurationMessages.AntHomeClasspathEntry_11, antHomeLocation), null);
 		}
 		return lib;
 	}
@@ -138,7 +138,7 @@ public class AntHomeClasspathEntry extends AbstractRuntimeClasspathEntry {
 		if (antHomeLocation == null) {
 			return AntLaunchConfigurationMessages.AntHomeClasspathEntry_8;
 		}
-		return MessageFormat.format(AntLaunchConfigurationMessages.AntHomeClasspathEntry_9, new Object[] { antHomeLocation });
+		return MessageFormat.format(AntLaunchConfigurationMessages.AntHomeClasspathEntry_9, antHomeLocation);
 	}
 
 	@Override

--- a/ant/org.eclipse.ant.launching/src/org/eclipse/ant/internal/launching/launchConfigurations/AntLaunchDelegate.java
+++ b/ant/org.eclipse.ant.launching/src/org/eclipse/ant/internal/launching/launchConfigurations/AntLaunchDelegate.java
@@ -124,8 +124,7 @@ public class AntLaunchDelegate extends LaunchConfigurationDelegate {
 		if (!path.isEmpty()) {
 			IPath jrePath = IPath.fromPortableString(path);
 			IVMInstall vm = JavaRuntime.getVMInstall(jrePath);
-			if (vm instanceof AbstractVMInstall) {
-				AbstractVMInstall install = (AbstractVMInstall) vm;
+			if (vm instanceof AbstractVMInstall install) {
 				vmver = install.getJavaVersion();
 				// versionToJdkLevel only handles 3 char versions = 1.5, 1.6, 1.9, etc
 				if (vmver.length() > 3) {
@@ -143,8 +142,7 @@ public class AntLaunchDelegate extends LaunchConfigurationDelegate {
 		}
 		if (vmver == null) {
 			IVMInstall vm = JavaRuntime.getDefaultVMInstall();
-			if (vm instanceof AbstractVMInstall) {
-				AbstractVMInstall install = (AbstractVMInstall) vm;
+			if (vm instanceof AbstractVMInstall install) {
 				vmver = install.getJavaVersion();
 			}
 
@@ -162,11 +160,9 @@ public class AntLaunchDelegate extends LaunchConfigurationDelegate {
 		boolean isSeparateJRE = AntLaunchingUtil.isSeparateJREAntBuild(configuration);
 
 		if (AntLaunchingUtil.isLaunchInBackground(configuration)) {
-			monitor.beginTask(MessageFormat.format(AntLaunchConfigurationMessages.AntLaunchDelegate_Launching__0__1, new Object[] {
-					configuration.getName() }), 10);
+			monitor.beginTask(MessageFormat.format(AntLaunchConfigurationMessages.AntLaunchDelegate_Launching__0__1, configuration.getName()), 10);
 		} else {
-			monitor.beginTask(MessageFormat.format(AntLaunchConfigurationMessages.AntLaunchDelegate_Running__0__2, new Object[] {
-					configuration.getName() }), 100);
+			monitor.beginTask(MessageFormat.format(AntLaunchConfigurationMessages.AntLaunchDelegate_Running__0__2, configuration.getName()), 100);
 		}
 
 		// resolve location
@@ -178,8 +174,7 @@ public class AntLaunchDelegate extends LaunchConfigurationDelegate {
 		}
 
 		if (!isSeparateJRE && AntRunner.isBuildRunning()) {
-			IStatus status = new Status(IStatus.ERROR, AntLaunching.PLUGIN_ID, 1, MessageFormat.format(AntLaunchConfigurationMessages.AntLaunchDelegate_Build_In_Progress, new Object[] {
-					location.toOSString() }), null);
+			IStatus status = new Status(IStatus.ERROR, AntLaunching.PLUGIN_ID, 1, MessageFormat.format(AntLaunchConfigurationMessages.AntLaunchDelegate_Build_In_Progress, location.toOSString()), null);
 			throw new CoreException(status);
 		}
 
@@ -255,8 +250,7 @@ public class AntLaunchDelegate extends LaunchConfigurationDelegate {
 		StringBuffer commandLine = generateCommandLine(location, arguments, userProperties, propertyFiles, targets, antHome, basedir, isSeparateJRE, captureOutput, setInputHandler, vmver);
 
 		if (isSeparateJRE) {
-			monitor.beginTask(MessageFormat.format(AntLaunchConfigurationMessages.AntLaunchDelegate_Launching__0__1, new Object[] {
-					configuration.getName() }), 10);
+			monitor.beginTask(MessageFormat.format(AntLaunchConfigurationMessages.AntLaunchDelegate_Launching__0__1, configuration.getName()), 10);
 			runInSeparateVM(configuration, launch, monitor, idStamp, antHome, port, requestPort, commandLine, captureOutput, setInputHandler);
 		} else {
 			runInSameVM(configuration, launch, monitor, location, idStamp, runner, commandLine);


### PR DESCRIPTION
### The following cleanups where applied:

- Add final modifier to private fields
- Add missing '<span>@</span>Deprecated' annotations
- Add missing '<span>@</span>Override' annotations
- Add missing '<span>@</span>Override' annotations to implementations of interface methods
- Convert control statement bodies to block
- Make inner classes static where possible
- Remove unnecessary array creation for varargs
- Remove unnecessary suppress warning tokens
- Replace deprecated calls with inlined content where possible
- Use pattern matching for instanceof

