### PR TITLE
Clean Code for ant/org.eclipse.ant.tests.ui

### DIFF
--- a/.github/workflows/cc2.yml
+++ b/.github/workflows/cc2.yml
@@ -1,0 +1,17 @@
+name: Perform Code Clean 2
+concurrency: 
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+on:
+  workflow_dispatch:
+
+jobs:
+  clean-code:
+    uses: laeubi/eclipse.platform.releng.aggregator/.github/workflows/cleanCode.yml@limit_number_of_cleanup_prs
+    with:
+      author: Eclipse Platform Bot <platform-bot@eclipse.org>
+      do-quickfix: false
+      do-cleanups: true
+      bundle-folders: ant/*/ debug/*/ resources/bundles/*/ runtime/bundles/*/ team/bundles/*/ ua/*/ update/*/ platform/*/
+    secrets:
+      token: ${{ secrets.PLATFORM_BOT_PAT }}

--- a/.github/workflows/cc3.yml
+++ b/.github/workflows/cc3.yml
@@ -1,0 +1,17 @@
+name: Perform Code Clean 3
+concurrency: 
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+on:
+  workflow_dispatch:
+
+jobs:
+  clean-code:
+    uses: laeubi/eclipse.platform.releng.aggregator/.github/workflows/cleanCode.yml@limit_number_of_cleanup_prs
+    with:
+      author: Eclipse Platform Bot <platform-bot@eclipse.org>
+      do-quickfix: false
+      do-cleanups: true
+      bundle-folders: ant/*/ debug/*/ resources/bundles/*/ runtime/bundles/*/ team/bundles/*/ ua/*/ update/*/ platform/*/
+    secrets:
+      token: ${{ secrets.PLATFORM_BOT_PAT }}

--- a/.github/workflows/cc4.yml
+++ b/.github/workflows/cc4.yml
@@ -1,0 +1,17 @@
+name: Perform Code Clean 4
+concurrency: 
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+on:
+  workflow_dispatch:
+
+jobs:
+  clean-code:
+    uses: laeubi/eclipse.platform.releng.aggregator/.github/workflows/cleanCode.yml@limit_number_of_cleanup_prs
+    with:
+      author: Eclipse Platform Bot <platform-bot@eclipse.org>
+      do-quickfix: false
+      do-cleanups: true
+      bundle-folders: ant/*/ debug/*/ resources/bundles/*/ runtime/bundles/*/ team/bundles/*/ ua/*/ update/*/ platform/*/
+    secrets:
+      token: ${{ secrets.PLATFORM_BOT_PAT }}

--- a/.github/workflows/doCleanCode.yml
+++ b/.github/workflows/doCleanCode.yml
@@ -1,0 +1,17 @@
+name: Perform Code Clean
+concurrency: 
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+on:
+  workflow_dispatch:
+
+jobs:
+  clean-code:
+    uses: laeubi/eclipse.platform.releng.aggregator/.github/workflows/cleanCode.yml@limit_number_of_cleanup_prs
+    with:
+      author: Eclipse Platform Bot <platform-bot@eclipse.org>
+      do-quickfix: false
+      do-cleanups: true
+      bundle-folders: ant/*/ debug/*/ resources/bundles/*/ runtime/bundles/*/ team/bundles/*/ ua/*/ update/*/ platform/*/
+    secrets:
+      token: ${{ secrets.PLATFORM_BOT_PAT }}

--- a/ant/org.eclipse.ant.tests.ui/Ant Editor Tests/org/eclipse/ant/tests/ui/editor/performance/EditorTestHelper.java
+++ b/ant/org.eclipse.ant.tests.ui/Ant Editor Tests/org/eclipse/ant/tests/ui/editor/performance/EditorTestHelper.java
@@ -37,15 +37,17 @@ public class EditorTestHelper {
 
 	public static IEditorPart openInEditor(IFile file, boolean runEventLoop) throws PartInitException {
 		IEditorPart part = IDE.openEditor(getActivePage(), file);
-		if (runEventLoop)
+		if (runEventLoop) {
 			runEventQueue(part);
+		}
 		return part;
 	}
 
 	public static IEditorPart openInEditor(IFile file, String editorId, boolean runEventLoop) throws PartInitException {
 		IEditorPart part = IDE.openEditor(getActivePage(), file, editorId);
-		if (runEventLoop)
+		if (runEventLoop) {
 			runEventQueue(part);
+		}
 		return part;
 	}
 
@@ -57,20 +59,23 @@ public class EditorTestHelper {
 
 	public static void revertEditor(ITextEditor editor, boolean runEventQueue) {
 		editor.doRevertToSaved();
-		if (runEventQueue)
+		if (runEventQueue) {
 			runEventQueue(editor);
+		}
 	}
 
 	public static void closeAllEditors() {
 		IWorkbenchPage page = getActivePage();
-		if (page != null)
+		if (page != null) {
 			page.closeAllEditors(false);
+		}
 	}
 
 	public static void runEventQueue() {
 		IWorkbenchWindow window = getActiveWorkbenchWindow();
-		if (window != null)
+		if (window != null) {
 			runEventQueue(window.getShell());
+		}
 	}
 
 	public static void runEventQueue(IWorkbenchPart part) {
@@ -108,8 +113,9 @@ public class EditorTestHelper {
 	public static boolean calmDown(long minTime, long maxTime, long intervalTime) {
 		long startTime = System.currentTimeMillis() + minTime;
 		runEventQueue();
-		while (System.currentTimeMillis() < startTime)
+		while (System.currentTimeMillis() < startTime) {
 			runEventQueue(intervalTime);
+		}
 
 		long endTime = maxTime > 0 ? System.currentTimeMillis() + maxTime : Long.MAX_VALUE;
 		boolean calm = isCalm();

--- a/ant/org.eclipse.ant.tests.ui/Ant Tests/org/eclipse/ant/tests/ui/AntViewTests.java
+++ b/ant/org.eclipse.ant.tests.ui/Ant Tests/org/eclipse/ant/tests/ui/AntViewTests.java
@@ -55,8 +55,7 @@ public class AntViewTests extends AbstractAntUITest {
 		IContributionItem[] actions = toolBarMgr.getItems();
 		if (actions != null && actions.length > 0) {
 			for (IContributionItem action : actions) {
-				if (action instanceof ActionContributionItem) {
-					ActionContributionItem actionItem = (ActionContributionItem) action;
+				if (action instanceof ActionContributionItem actionItem) {
 					if (actionItem.getAction() instanceof AddBuildFilesAction) {
 						return (AddBuildFilesAction) actionItem.getAction();
 					}

--- a/ant/org.eclipse.ant.tests.ui/test plugin/org/eclipse/ant/tests/ui/testplugin/DebugEventWaiter.java
+++ b/ant/org.eclipse.ant.tests.ui/test plugin/org/eclipse/ant/tests/ui/testplugin/DebugEventWaiter.java
@@ -148,8 +148,9 @@ public class DebugEventWaiter implements IDebugEventSetListener {
 			}
 		}
 		unregister();
-		if (fEvent == null)
+		if (fEvent == null) {
 			return null;
+		}
 		return fEvent.getSource();
 	}
 


### PR DESCRIPTION
### The following cleanups where applied:

- Add final modifier to private fields
- Add missing '<span>@</span>Deprecated' annotations
- Add missing '<span>@</span>Override' annotations
- Add missing '<span>@</span>Override' annotations to implementations of interface methods
- Convert control statement bodies to block
- Make inner classes static where possible
- Remove unnecessary array creation for varargs
- Remove unnecessary suppress warning tokens
- Replace deprecated calls with inlined content where possible
- Use pattern matching for instanceof

