### PR TITLE
Clean Code for ant/org.eclipse.ant.ui

### DIFF
--- a/.github/workflows/cc2.yml
+++ b/.github/workflows/cc2.yml
@@ -1,0 +1,17 @@
+name: Perform Code Clean 2
+concurrency: 
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+on:
+  workflow_dispatch:
+
+jobs:
+  clean-code:
+    uses: laeubi/eclipse.platform.releng.aggregator/.github/workflows/cleanCode.yml@limit_number_of_cleanup_prs
+    with:
+      author: Eclipse Platform Bot <platform-bot@eclipse.org>
+      do-quickfix: false
+      do-cleanups: true
+      bundle-folders: ant/*/ debug/*/ resources/bundles/*/ runtime/bundles/*/ team/bundles/*/ ua/*/ update/*/ platform/*/
+    secrets:
+      token: ${{ secrets.PLATFORM_BOT_PAT }}

--- a/.github/workflows/cc3.yml
+++ b/.github/workflows/cc3.yml
@@ -1,0 +1,17 @@
+name: Perform Code Clean 3
+concurrency: 
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+on:
+  workflow_dispatch:
+
+jobs:
+  clean-code:
+    uses: laeubi/eclipse.platform.releng.aggregator/.github/workflows/cleanCode.yml@limit_number_of_cleanup_prs
+    with:
+      author: Eclipse Platform Bot <platform-bot@eclipse.org>
+      do-quickfix: false
+      do-cleanups: true
+      bundle-folders: ant/*/ debug/*/ resources/bundles/*/ runtime/bundles/*/ team/bundles/*/ ua/*/ update/*/ platform/*/
+    secrets:
+      token: ${{ secrets.PLATFORM_BOT_PAT }}

--- a/.github/workflows/cc4.yml
+++ b/.github/workflows/cc4.yml
@@ -1,0 +1,17 @@
+name: Perform Code Clean 4
+concurrency: 
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+on:
+  workflow_dispatch:
+
+jobs:
+  clean-code:
+    uses: laeubi/eclipse.platform.releng.aggregator/.github/workflows/cleanCode.yml@limit_number_of_cleanup_prs
+    with:
+      author: Eclipse Platform Bot <platform-bot@eclipse.org>
+      do-quickfix: false
+      do-cleanups: true
+      bundle-folders: ant/*/ debug/*/ resources/bundles/*/ runtime/bundles/*/ team/bundles/*/ ua/*/ update/*/ platform/*/
+    secrets:
+      token: ${{ secrets.PLATFORM_BOT_PAT }}

--- a/.github/workflows/doCleanCode.yml
+++ b/.github/workflows/doCleanCode.yml
@@ -1,0 +1,17 @@
+name: Perform Code Clean
+concurrency: 
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+on:
+  workflow_dispatch:
+
+jobs:
+  clean-code:
+    uses: laeubi/eclipse.platform.releng.aggregator/.github/workflows/cleanCode.yml@limit_number_of_cleanup_prs
+    with:
+      author: Eclipse Platform Bot <platform-bot@eclipse.org>
+      do-quickfix: false
+      do-cleanups: true
+      bundle-folders: ant/*/ debug/*/ resources/bundles/*/ runtime/bundles/*/ team/bundles/*/ ua/*/ update/*/ platform/*/
+    secrets:
+      token: ${{ secrets.PLATFORM_BOT_PAT }}

--- a/ant/org.eclipse.ant.ui/Ant Editor/org/eclipse/ant/internal/ui/dtd/Parser.java
+++ b/ant/org.eclipse.ant.ui/Ant Editor/org/eclipse/ant/internal/ui/dtd/Parser.java
@@ -199,8 +199,9 @@ public class Parser {
 
 		@Override
 		public InputSource resolveEntity(String publicId, String systemId) {
-			if (publicId.equals(INTERNAL) && systemId.equals(INTERNAL))
+			if (publicId.equals(INTERNAL) && systemId.equals(INTERNAL)) {
 				return new InputSource(reader);
+			}
 			return null;
 		}
 	}

--- a/ant/org.eclipse.ant.ui/Ant Editor/org/eclipse/ant/internal/ui/dtd/schema/Dfm.java
+++ b/ant/org.eclipse.ant.ui/Ant Editor/org/eclipse/ant/internal/ui/dtd/schema/Dfm.java
@@ -47,8 +47,9 @@ public class Dfm extends MapHolder implements IDfm, FactoryObject {
 
 	private static Dfm free() {
 		Dfm dfm = (Dfm) factory.getFree();
-		if (dfm == null)
+		if (dfm == null) {
 			dfm = new Dfm();
+		}
 		dfm.accepting = dfm.empty = dfm.any = false;
 		dfm.id = unique++;
 		return dfm;
@@ -76,12 +77,15 @@ public class Dfm extends MapHolder implements IDfm, FactoryObject {
 
 	@Override
 	public IDfm advance(String name) {
-		if (any)
+		if (any) {
 			return this;
-		if (empty)
+		}
+		if (empty) {
 			return null;
-		if (keys == null)
+		}
+		if (keys == null) {
 			return null;
+		}
 		SortedMap map = getIndirectStringMap(this);
 		Dfm dfm = (Dfm) map.get(name);
 		freeMap(map);
@@ -90,8 +94,9 @@ public class Dfm extends MapHolder implements IDfm, FactoryObject {
 
 	@Override
 	public String[] getAccepts() {
-		if (keys == null)
+		if (keys == null) {
 			return new String[0];
+		}
 		String[] s = new String[keys.length];
 		for (int i = 0; i < s.length; i++) {
 			s[i] = keys[i].toString();
@@ -100,8 +105,9 @@ public class Dfm extends MapHolder implements IDfm, FactoryObject {
 	}
 
 	public Dfm[] getFollows() {
-		if (values == null)
+		if (values == null) {
 			return new Dfm[0];
+		}
 		Dfm[] s = new Dfm[values.length];
 		System.arraycopy(values, 0, s, 0, values.length);
 		return s;

--- a/ant/org.eclipse.ant.ui/Ant Editor/org/eclipse/ant/internal/ui/dtd/schema/Model.java
+++ b/ant/org.eclipse.ant.ui/Ant Editor/org/eclipse/ant/internal/ui/dtd/schema/Model.java
@@ -65,11 +65,13 @@ public class Model implements IModel {
 	}
 
 	public void addModel(IModel model) {
-		if (fContents != null)
+		if (fContents != null) {
 			throw new IllegalStateException(AntDTDSchemaMessages.Model_model_may_not_be_changed);
+		}
 
-		if (fContentsList == null)
+		if (fContentsList == null) {
 			fContentsList = new LinkedList<>();
+		}
 
 		fContentsList.add(model);
 	}
@@ -81,10 +83,12 @@ public class Model implements IModel {
 	private static final String[] fOps = { "?", ",", "|", "&", "!!!" }; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
 
 	private Nfm qualifyNfm(Nfm nfm) {
-		if (nfm == null)
+		if (nfm == null) {
 			return null;
-		if (fMin == 1 && fMax == 1)
+		}
+		if (fMin == 1 && fMax == 1) {
 			return nfm;
+		}
 		if (fMin == 0 && fMax == 1) {
 			return Nfm.getQuestion(nfm);
 		}
@@ -95,8 +99,9 @@ public class Model implements IModel {
 			return Nfm.getPlus(nfm);
 		}
 		// the following cases cannot be reached by DTD models
-		if (fMax == 0)
+		if (fMax == 0) {
 			return Nfm.getNfm(null);
+		}
 		if (fMax == UNBOUNDED) {
 			return Nfm.getUnbounded(nfm, fMin);
 		}
@@ -146,8 +151,9 @@ public class Model implements IModel {
 			if (fContentsList != null) {
 				fContents = fContentsList.toArray(new IModel[fContentsList.size()]);
 				fContentsList = null;
-			} else
+			} else {
 				fContents = fEmptyContents;
+			}
 		}
 		return fContents;
 	}
@@ -178,8 +184,9 @@ public class Model implements IModel {
 				while (it.hasNext()) {
 					Model model = (Model) it.next();
 					model.stringRep(buf);
-					if (it.hasNext())
+					if (it.hasNext()) {
 						buf.append(getOperator());
+					}
 				}
 				buf.append(')');
 				buf.append(getQualifier());

--- a/ant/org.eclipse.ant.ui/Ant Editor/org/eclipse/ant/internal/ui/dtd/schema/Nfm.java
+++ b/ant/org.eclipse.ant.ui/Ant Editor/org/eclipse/ant/internal/ui/dtd/schema/Nfm.java
@@ -227,10 +227,12 @@ public class Nfm implements FactoryObject {
 	 * "{min,*}" an existing nfm x -&gt; x[0],x[1],...,x[min-1],x[min]* Frees x.
 	 */
 	public static Nfm getUnbounded(Nfm x, int min) {
-		if (min == 0)
+		if (min == 0) {
 			return getStar(x);
-		if (min == 1)
+		}
+		if (min == 1) {
 			return getPlus(x);
+		}
 		Nfm last1 = nfm(x), last2 = nfm(x);
 		for (int i = 2; i < min; i++) {
 			last1 = getComma(last1, last2);
@@ -245,32 +247,34 @@ public class Nfm implements FactoryObject {
 	 * "{min,max}" an existing nfm x -&gt; x[0],x[1],...,x[min-1],x[min]?,...,x[max-1]? Frees or returns x.
 	 */
 	public static Nfm getMinMax(Nfm x, int min, int max) {
-		if (max == Integer.MAX_VALUE)
+		if (max == Integer.MAX_VALUE) {
 			return getUnbounded(x, min);
+		}
 		if (max == 0) {
 			free(x);
 			return nfm((IAtom) null);
 		}
 		if (max == 1) {
-			if (min == 0)
+			if (min == 0) {
 				return getQuestion(x);
+			}
 			return x;
 		}
 		Nfm last = null;
 		int i = 0;
 		for (; i < min; i++) {
-			if (last == null)
+			if (last == null) {
 				last = nfm(x);
-			else {
+			} else {
 				Nfm tmp = nfm(x);
 				last = getComma(last, tmp);
 				free(tmp);
 			}
 		}
 		for (; i < max; i++) {
-			if (last == null)
+			if (last == null) {
 				last = getQuestion(x);
-			else {
+			} else {
 				Nfm tmp = getQuestion(x);
 				last = getComma(last, tmp);
 				free(tmp);
@@ -300,8 +304,9 @@ public class Nfm implements FactoryObject {
 
 	private static Nfm free() {
 		Nfm nfm = (Nfm) fFactory.getFree();
-		if (nfm == null)
+		if (nfm == null) {
 			return new Nfm();
+		}
 		return nfm;
 	}
 

--- a/ant/org.eclipse.ant.ui/Ant Editor/org/eclipse/ant/internal/ui/dtd/schema/NfmNode.java
+++ b/ant/org.eclipse.ant.ui/Ant Editor/org/eclipse/ant/internal/ui/dtd/schema/NfmNode.java
@@ -100,8 +100,9 @@ public class NfmNode implements FactoryObject {
 
 	private static NfmNode getFree() {
 		NfmNode nfm = (NfmNode) fFactory.getFree();
-		if (nfm == null)
+		if (nfm == null) {
 			nfm = new NfmNode();
+		}
 		nfm.next(fUsed);
 		fUsed = nfm;
 		return nfm;

--- a/ant/org.eclipse.ant.ui/Ant Editor/org/eclipse/ant/internal/ui/dtd/schema/NfmParser.java
+++ b/ant/org.eclipse.ant.ui/Ant Editor/org/eclipse/ant/internal/ui/dtd/schema/NfmParser.java
@@ -73,7 +73,7 @@ public class NfmParser {
 	}
 
 	private void reportError(String name) throws ParseError {
-		throw new ParseError(MessageFormat.format(AntDTDSchemaMessages.NfmParser_Ambiguous, new Object[] { name }));
+		throw new ParseError(MessageFormat.format(AntDTDSchemaMessages.NfmParser_Ambiguous, name));
 	}
 
 	public static void collect(Dfm dfm, List<Dfm> dfms) {
@@ -103,8 +103,9 @@ public class NfmParser {
 			if (follows != null) {
 				for (int j = 0; j < follows.length; j++) {
 					Dfm replacement, follow = (Dfm) follows[j];
-					while ((replacement = removed.get(follow)) != null)
+					while ((replacement = removed.get(follow)) != null) {
 						follow = replacement;
+					}
 					follows[j] = follow;
 				}
 			}
@@ -135,8 +136,9 @@ public class NfmParser {
 					// accepts strings are interned allowing identity comparison
 
 					if (last != null && last == accept) {
-						if (follows[i] != follows[lasti])
+						if (follows[i] != follows[lasti]) {
 							checkConflict(new Conflict(accept, (Dfm) follows[lasti], (Dfm) follows[i]));
+						}
 					} else {
 						last = accept;
 						lasti = i;
@@ -187,8 +189,9 @@ public class NfmParser {
 					int i = 0;
 					for (Iterator<?> iterator = map.keyIterator(); iterator.hasNext(); i++) {
 						iterator.next();
-						if (removes[i])
+						if (removes[i]) {
 							iterator.remove();
+						}
 					}
 					SortedMapFactory.freeMap(map);
 				}
@@ -258,28 +261,33 @@ public class NfmParser {
 	private Dfm parse(int mark, NfmNode start, NfmNode accept) {
 
 		// eliminate useless recursion (note that accept node has no branches)
-		while (start.next1 != null && start.next2 == null && start.symbol == null)
+		while (start.next1 != null && start.next2 == null && start.symbol == null) {
 			start = start.next1;
+		}
 
 		// if we reached the accept node, return an empty dfm that accepts
-		if (start == accept)
+		if (start == accept) {
 			return Dfm.dfm(true);
+		}
 
 		// for a symbol, construct a dfm that accepts the symbol
 		if (start.symbol != null) {
 			Dfm nextdfm = null;
 			NfmNode next = start.next1, snext = next;
-			while (snext.dfm == null && snext.next1 != null && snext.next2 == null && snext.symbol == null)
+			while (snext.dfm == null && snext.next1 != null && snext.next2 == null && snext.symbol == null) {
 				snext = snext.next1;
+			}
 			if (snext.dfm != null) {
-				for (NfmNode n = next; n != snext; n = n.next1)
+				for (NfmNode n = next; n != snext; n = n.next1) {
 					n.dfm = snext.dfm;
+				}
 				nextdfm = snext.dfm;
 			} else {
 				nextdfm = Dfm.dfm(false);
 				snext.dfm = nextdfm;
-				for (NfmNode n = next; n != snext; n = n.next1)
+				for (NfmNode n = next; n != snext; n = n.next1) {
 					n.dfm = nextdfm;
+				}
 				parseNext(mark, nextdfm, snext, accept);
 			}
 			Dfm dfm = Dfm.dfm(start.symbol, nextdfm);
@@ -303,10 +311,11 @@ public class NfmParser {
 		}
 
 		if (dfm2 != null) {
-			if (dfm1 != null)
+			if (dfm1 != null) {
 				dfm1.merge(dfm2);
-			else
+			} else {
 				dfm1 = dfm2;
+			}
 		}
 		return dfm1;
 	}
@@ -328,11 +337,12 @@ public class NfmParser {
 
 		@Override
 		public boolean equals(Object o) {
-			if (o == this)
+			if (o == this) {
 				return true;
-			if (!(o instanceof Conflict))
+			}
+			if (!(o instanceof Conflict other)) {
 				return false;
-			Conflict other = (Conflict) o;
+			}
 			return (dfm1 == other.dfm1 && dfm2 == other.dfm2) || (dfm1 == other.dfm2 && dfm2 == other.dfm1);
 		}
 	}

--- a/ant/org.eclipse.ant.ui/Ant Editor/org/eclipse/ant/internal/ui/dtd/schema/SchemaFactory.java
+++ b/ant/org.eclipse.ant.ui/Ant Editor/org/eclipse/ant/internal/ui/dtd/schema/SchemaFactory.java
@@ -76,11 +76,11 @@ public class SchemaFactory implements DeclHandler {
 			element.addAttribute(attr);
 
 			String[] enumeration = null;
-			if (fTypes.contains(type))
+			if (fTypes.contains(type)) {
 				attr.setType(type);
-			else if (type.startsWith("NOTATION")) //$NON-NLS-1$
+			} else if (type.startsWith("NOTATION")) { //$NON-NLS-1$
 				enumeration = parseValues(type.substring("NOTATION".length() + 1), ','); //$NON-NLS-1$
-			else {
+			} else {
 				type = stripSurroundingParentheses(type);
 				enumeration = parseValues(type, '|');
 			}
@@ -126,8 +126,9 @@ public class SchemaFactory implements DeclHandler {
 		LinkedList<String> values = new LinkedList<>();
 		while (start < len) {
 			pos = type.indexOf(separator, start);
-			if (pos < 0)
+			if (pos < 0) {
 				pos = len;
+			}
 			String term = type.substring(start, pos);
 			start = pos + 1;
 			values.add(term);
@@ -140,7 +141,7 @@ public class SchemaFactory implements DeclHandler {
 		Element element = getElement(name);
 		if (!element.isUndefined()) {
 			// if the element has already been defined, this is an error
-			throw new SAXException(MessageFormat.format(AntDTDSchemaMessages.SchemaFactory_Doubly_defined, new Object[] { name }));
+			throw new SAXException(MessageFormat.format(AntDTDSchemaMessages.SchemaFactory_Doubly_defined, name));
 		}
 
 		fElement = element;
@@ -170,8 +171,7 @@ public class SchemaFactory implements DeclHandler {
 		fBuf = model.toCharArray();
 		fLen = fBuf.length;
 		if (fBuf[0] != '(') {
-			throw new SAXException(MessageFormat.format(AntDTDSchemaMessages.SchemaFactory_Start_with_left_parenthesis, new Object[] {
-					fElement.getName() }));
+			throw new SAXException(MessageFormat.format(AntDTDSchemaMessages.SchemaFactory_Start_with_left_parenthesis, fElement.getName()));
 		}
 
 		boolean ortext = model.startsWith("(#PCDATA|"); //$NON-NLS-1$
@@ -209,8 +209,7 @@ public class SchemaFactory implements DeclHandler {
 		if (fBuf[fPos] != ')') {
 			char op = fBuf[fPos];
 			if (op != '|' && op != ',') {
-				throw new SAXException(MessageFormat.format(AntDTDSchemaMessages.SchemaFactory_Expecting_operator_or_right_parenthesis, new Object[] {
-						fElement.getName(), String.valueOf(fBuf) }));
+				throw new SAXException(MessageFormat.format(AntDTDSchemaMessages.SchemaFactory_Expecting_operator_or_right_parenthesis, fElement.getName(), String.valueOf(fBuf)));
 			}
 			Model model = new Model(op == '|' ? IModel.CHOICE : IModel.SEQUENCE);
 			model.addModel(term);
@@ -222,8 +221,7 @@ public class SchemaFactory implements DeclHandler {
 				model.addModel(next);
 			}
 			if (fBuf[fPos] != ')') {
-				throw new SAXException(MessageFormat.format(AntDTDSchemaMessages.SchemaFactory_Expecting_operator_or_right_parenthesis, new Object[] {
-						fElement.getName(), String.valueOf(fBuf) }));
+				throw new SAXException(MessageFormat.format(AntDTDSchemaMessages.SchemaFactory_Expecting_operator_or_right_parenthesis, fElement.getName(), String.valueOf(fBuf)));
 			}
 			fPos++;
 		}
@@ -237,8 +235,9 @@ public class SchemaFactory implements DeclHandler {
 	 */
 	private IModel scanElement() throws SAXException {
 		checkLen();
-		if (fBuf[fPos] == '(')
+		if (fBuf[fPos] == '(') {
 			return scanExpr();
+		}
 		StringBuilder sb = new StringBuilder();
 		while (fBuf[fPos] != '|' && fBuf[fPos] != ',' && fBuf[fPos] != ')' && fBuf[fPos] != '*' && fBuf[fPos] != '+' && fBuf[fPos] != '?') {
 			sb.append(fBuf[fPos++]);
@@ -253,8 +252,7 @@ public class SchemaFactory implements DeclHandler {
 
 	private void checkLen() throws SAXException {
 		if (fPos == fLen) {
-			throw new SAXException(MessageFormat.format(AntDTDSchemaMessages.SchemaFactory_Unexpected_end, new Object[] { fElement.getName(),
-					String.valueOf(fBuf) }));
+			throw new SAXException(MessageFormat.format(AntDTDSchemaMessages.SchemaFactory_Unexpected_end, fElement.getName(), String.valueOf(fBuf)));
 		}
 	}
 

--- a/ant/org.eclipse.ant.ui/Ant Editor/org/eclipse/ant/internal/ui/dtd/util/SortedMap.java
+++ b/ant/org.eclipse.ant.ui/Ant Editor/org/eclipse/ant/internal/ui/dtd/util/SortedMap.java
@@ -67,8 +67,9 @@ public class SortedMap implements FactoryObject {
 		Object result = index >= 0 && values != null ? values[index] : null;
 
 		int i = fSet.internalAdd(key, false);
-		if (i >= 0)
+		if (i >= 0) {
 			internalPut(i, val);
+		}
 		return result;
 	}
 
@@ -102,21 +103,25 @@ public class SortedMap implements FactoryObject {
 
 	public Object get(Object key) {
 		Object[] values = fHolder.getValues();
-		if (values == null)
+		if (values == null) {
 			return null;
+		}
 		int i = fSet.indexOf(key);
-		if (i >= 0)
+		if (i >= 0) {
 			return values[i];
+		}
 		return null;
 	}
 
 	public Object getIdentity(Object key) {
 		Object[] values = fHolder.getValues();
-		if (values == null)
+		if (values == null) {
 			return null;
+		}
 		int i = fSet.indexOfIdentity(key);
-		if (i >= 0)
+		if (i >= 0) {
 			return values[i];
+		}
 		return null;
 	}
 
@@ -126,8 +131,9 @@ public class SortedMap implements FactoryObject {
 
 	public Object[] values() {
 		Object[] values = fHolder.getValues();
-		if (values == null)
+		if (values == null) {
 			return new Object[0];
+		}
 		return values;
 	}
 
@@ -149,16 +155,18 @@ public class SortedMap implements FactoryObject {
 		@Override
 		public boolean hasNext() {
 			Object[] array = SortedMap.this.fHolder.getKeys();
-			if (array == null)
+			if (array == null) {
 				return false;
+			}
 			return fIndex + 1 < array.length;
 		}
 
 		@Override
 		public Object next() {
 			Object[] array = SortedMap.this.fHolder.getKeys();
-			if (array == null)
+			if (array == null) {
 				throw new IllegalStateException(AntDTDUtilMessages.SortedMap_next___called_for_empty_array_1);
+			}
 			return array[++fIndex];
 		}
 
@@ -173,8 +181,7 @@ public class SortedMap implements FactoryObject {
 	public void remove(int i) {
 		Object[] values = fHolder.getValues();
 		if (values == null) {
-			throw new IllegalArgumentException(MessageFormat.format(AntDTDUtilMessages.SortedMap_remove__0___in_empty_map_2, new Object[] {
-					Integer.toString(i) }));
+			throw new IllegalArgumentException(MessageFormat.format(AntDTDUtilMessages.SortedMap_remove__0___in_empty_map_2, Integer.toString(i)));
 		}
 		fSet.remove(i);
 		Object[] tmp = new Object[values.length - 1];
@@ -185,8 +192,9 @@ public class SortedMap implements FactoryObject {
 
 	public Object remove(Object obj) {
 		Object[] values = fHolder.getValues();
-		if (values == null)
+		if (values == null) {
 			return null;
+		}
 		int i = fSet.indexOf(obj);
 		if (i >= 0) {
 			Object tmp = values[i];
@@ -199,8 +207,9 @@ public class SortedMap implements FactoryObject {
 
 	public Object removeIdentity(Object obj) {
 		Object[] values = fHolder.getValues();
-		if (values == null)
+		if (values == null) {
 			return null;
+		}
 		int i = fSet.indexOfIdentity(obj);
 		if (i >= 0) {
 			Object tmp = values[i];
@@ -224,8 +233,9 @@ public class SortedMap implements FactoryObject {
 		Object[] keys = fHolder.getKeys();
 		Object[] othervalues = other.fHolder.getValues();
 		Object[] otherkeys = other.fHolder.getKeys();
-		if (otherkeys == null)
+		if (otherkeys == null) {
 			return;
+		}
 		if (keys == null) {
 			fHolder.setKeys(otherkeys);
 			fHolder.setValues(othervalues);

--- a/ant/org.eclipse.ant.ui/Ant Editor/org/eclipse/ant/internal/ui/dtd/util/SortedMapFactory.java
+++ b/ant/org.eclipse.ant.ui/Ant Editor/org/eclipse/ant/internal/ui/dtd/util/SortedMapFactory.java
@@ -35,8 +35,9 @@ public class SortedMapFactory {
 
 	public static SortedMap getMap(IMapHolder holder, Comparator<Object> comp) {
 		SortedMap map = (SortedMap) fFactory.getFree();
-		if (map == null)
+		if (map == null) {
 			map = new SortedMap();
+		}
 		map.setMapHolder(holder);
 		map.setComparator(comp);
 		return map;

--- a/ant/org.eclipse.ant.ui/Ant Editor/org/eclipse/ant/internal/ui/dtd/util/SortedSet.java
+++ b/ant/org.eclipse.ant.ui/Ant Editor/org/eclipse/ant/internal/ui/dtd/util/SortedSet.java
@@ -87,8 +87,9 @@ public class SortedSet {
 				break;
 			}
 		}
-		if (comp == 0 && !always)
+		if (comp == 0 && !always) {
 			return -1;
+		}
 		internalAdd(i, obj);
 		return i;
 	}
@@ -135,14 +136,17 @@ public class SortedSet {
 
 	public int indexOf(Object obj) {
 		Object[] array = fKeyHolder.getKeys();
-		if (array == null)
+		if (array == null) {
 			return -1;
+		}
 		for (int i = 0; i < array.length; i++) {
 			int comp = fComp.compare(obj, array[i]);
-			if (comp == 0)
+			if (comp == 0) {
 				return i;
-			if (comp < 0)
+			}
+			if (comp < 0) {
 				return -1;
+			}
 		}
 		return -1;
 	}
@@ -153,33 +157,40 @@ public class SortedSet {
 
 	public int indexOfIdentity(Object obj) {
 		Object[] array = fKeyHolder.getKeys();
-		if (array == null)
+		if (array == null) {
 			return -1;
+		}
 		for (int i = 0; i < array.length; i++) {
-			if (obj == array[i])
+			if (obj == array[i]) {
 				return i;
+			}
 		}
 		return -1;
 	}
 
 	@Override
 	public boolean equals(Object o) {
-		if (this == o)
+		if (this == o) {
 			return true;
-		if (!(o instanceof SortedSet))
+		}
+		if (!(o instanceof SortedSet other)) {
 			return false;
-		SortedSet other = (SortedSet) o;
+		}
 		Object[] array = fKeyHolder.getKeys();
 		Object[] otherarray = other.fKeyHolder.getKeys();
-		if ((array == null) != (otherarray == null))
+		if ((array == null) != (otherarray == null)) {
 			return false;
-		if (array == null)
+		}
+		if (array == null) {
 			return true;
-		if (array.length != otherarray.length)
+		}
+		if (array.length != otherarray.length) {
 			return false;
+		}
 		for (int i = 0; i < array.length; i++) {
-			if (array[i] != otherarray[i])
+			if (array[i] != otherarray[i]) {
 				return false;
+			}
 		}
 		return true;
 	}
@@ -187,8 +198,9 @@ public class SortedSet {
 	public void merge(SortedSet other) {
 		Object[] array = fKeyHolder.getKeys();
 		Object[] otherarray = other.fKeyHolder.getKeys();
-		if (otherarray == null)
+		if (otherarray == null) {
 			return;
+		}
 		if (array == null) {
 			array = otherarray;
 			return;
@@ -214,8 +226,9 @@ public class SortedSet {
 
 	public Object[] members() {
 		Object[] array = fKeyHolder.getKeys();
-		if (array == null)
+		if (array == null) {
 			return new Object[0];
+		}
 		return array;
 	}
 

--- a/ant/org.eclipse.ant.ui/Ant Editor/org/eclipse/ant/internal/ui/editor/AntAutoEditStrategy.java
+++ b/ant/org.eclipse.ant.ui/Ant Editor/org/eclipse/ant/internal/ui/editor/AntAutoEditStrategy.java
@@ -114,8 +114,9 @@ public class AntAutoEditStrategy extends DefaultIndentLineAutoEditStrategy {
 
 	private boolean isLineDelimiter(IDocument document, String text) {
 		String[] delimiters = document.getLegalLineDelimiters();
-		if (delimiters != null)
+		if (delimiters != null) {
 			return TextUtilities.equals(delimiters, text) > -1;
+		}
 		return false;
 	}
 
@@ -237,8 +238,9 @@ public class AntAutoEditStrategy extends DefaultIndentLineAutoEditStrategy {
 		int to = from;
 		while (toDelete > 0 && to < endOffset) {
 			char ch = document.getChar(to);
-			if (!Character.isWhitespace(ch))
+			if (!Character.isWhitespace(ch)) {
 				break;
+			}
 			toDelete -= computeVisualLength(ch);
 			if (toDelete >= 0) {
 				to++;

--- a/ant/org.eclipse.ant.ui/Ant Editor/org/eclipse/ant/internal/ui/editor/AntEditor.java
+++ b/ant/org.eclipse.ant.ui/Ant Editor/org/eclipse/ant/internal/ui/editor/AntEditor.java
@@ -139,8 +139,7 @@ public class AntEditor extends TextEditor implements IReconcilingParticipant, IP
 				return;
 			}
 
-			if (selectionProvider instanceof IPostSelectionProvider) {
-				IPostSelectionProvider provider = (IPostSelectionProvider) selectionProvider;
+			if (selectionProvider instanceof IPostSelectionProvider provider) {
 				provider.addPostSelectionChangedListener(this);
 			} else {
 				selectionProvider.addSelectionChangedListener(this);
@@ -155,8 +154,7 @@ public class AntEditor extends TextEditor implements IReconcilingParticipant, IP
 				return;
 			}
 
-			if (selectionProvider instanceof IPostSelectionProvider) {
-				IPostSelectionProvider provider = (IPostSelectionProvider) selectionProvider;
+			if (selectionProvider instanceof IPostSelectionProvider provider) {
 				provider.removePostSelectionChangedListener(this);
 			} else {
 				selectionProvider.removeSelectionChangedListener(this);
@@ -168,8 +166,7 @@ public class AntEditor extends TextEditor implements IReconcilingParticipant, IP
 			AntModel model = getAntModel();
 			ISelection selection = event.getSelection();
 			AntElementNode node = null;
-			if (selection instanceof ITextSelection) {
-				ITextSelection textSelection = (ITextSelection) selection;
+			if (selection instanceof ITextSelection textSelection) {
 				int offset = textSelection.getOffset();
 				node = model.getNode(offset, false);
 				updateOccurrenceAnnotations(textSelection, model);
@@ -227,8 +224,9 @@ public class AntEditor extends TextEditor implements IReconcilingParticipant, IP
 			fSelection = selection;
 			fPositions = positions;
 
-			if (getSelectionProvider() instanceof ISelectionValidator)
+			if (getSelectionProvider() instanceof ISelectionValidator) {
 				fPostSelectionValidator = (ISelectionValidator) getSelectionProvider();
+			}
 		}
 
 		// cannot use cancel() because it is declared final
@@ -249,32 +247,38 @@ public class AntEditor extends TextEditor implements IReconcilingParticipant, IP
 
 			fProgressMonitor = progressMonitor;
 
-			if (isCanceled())
+			if (isCanceled()) {
 				return Status.CANCEL_STATUS;
+			}
 
 			ITextViewer textViewer = getViewer();
-			if (textViewer == null)
+			if (textViewer == null) {
 				return Status.CANCEL_STATUS;
+			}
 
 			IDocument document = textViewer.getDocument();
-			if (document == null)
+			if (document == null) {
 				return Status.CANCEL_STATUS;
+			}
 
 			IDocumentProvider documentProvider = getDocumentProvider();
-			if (documentProvider == null)
+			if (documentProvider == null) {
 				return Status.CANCEL_STATUS;
+			}
 
 			IAnnotationModel annotationModel = documentProvider.getAnnotationModel(getEditorInput());
-			if (annotationModel == null)
+			if (annotationModel == null) {
 				return Status.CANCEL_STATUS;
+			}
 
 			// Add occurrence annotations
 			int length = fPositions.size();
 			Map<Annotation, Position> annotationMap = new HashMap<>(length);
 			for (int i = 0; i < length; i++) {
 
-				if (isCanceled())
+				if (isCanceled()) {
 					return Status.CANCEL_STATUS;
+				}
 
 				String message;
 				Position position = fPositions.get(i);
@@ -331,37 +335,43 @@ public class AntEditor extends TextEditor implements IReconcilingParticipant, IP
 
 		public void install() {
 			ISourceViewer sourceViewer = getSourceViewer();
-			if (sourceViewer == null)
+			if (sourceViewer == null) {
 				return;
+			}
 
 			StyledText text = sourceViewer.getTextWidget();
-			if (text == null || text.isDisposed())
+			if (text == null || text.isDisposed()) {
 				return;
+			}
 
 			sourceViewer.addTextInputListener(this);
 
 			IDocument document = sourceViewer.getDocument();
-			if (document != null)
+			if (document != null) {
 				document.addDocumentListener(this);
+			}
 		}
 
 		public void uninstall() {
 			ISourceViewer sourceViewer = getSourceViewer();
-			if (sourceViewer != null)
+			if (sourceViewer != null) {
 				sourceViewer.removeTextInputListener(this);
+			}
 
 			IDocumentProvider documentProvider = getDocumentProvider();
 			if (documentProvider != null) {
 				IDocument document = documentProvider.getDocument(getEditorInput());
-				if (document != null)
+				if (document != null) {
 					document.removeDocumentListener(this);
+				}
 			}
 		}
 
 		@Override
 		public void documentAboutToBeChanged(DocumentEvent event) {
-			if (fOccurrencesFinderJob != null)
+			if (fOccurrencesFinderJob != null) {
 				fOccurrencesFinderJob.doCancel();
+			}
 		}
 
 		@Override
@@ -371,16 +381,18 @@ public class AntEditor extends TextEditor implements IReconcilingParticipant, IP
 
 		@Override
 		public void inputDocumentAboutToBeChanged(IDocument oldInput, IDocument newInput) {
-			if (oldInput == null)
+			if (oldInput == null) {
 				return;
+			}
 
 			oldInput.removeDocumentListener(this);
 		}
 
 		@Override
 		public void inputDocumentChanged(IDocument oldInput, IDocument newInput) {
-			if (newInput == null)
+			if (newInput == null) {
 				return;
+			}
 			newInput.addDocumentListener(this);
 		}
 	}
@@ -404,8 +416,9 @@ public class AntEditor extends TextEditor implements IReconcilingParticipant, IP
 
 		@Override
 		public void shellDeactivated(ShellEvent e) {
-			if (fMarkOccurrenceAnnotations && isActivePart())
+			if (fMarkOccurrenceAnnotations && isActivePart()) {
 				removeOccurrenceAnnotations();
+			}
 		}
 	}
 
@@ -687,8 +700,7 @@ public class AntEditor extends TextEditor implements IReconcilingParticipant, IP
 
 		if (AntEditorPreferenceConstants.EDITOR_FOLDING_ENABLED.equals(property)) {
 			ISourceViewer sourceViewer = getSourceViewer();
-			if (sourceViewer instanceof ProjectionViewer) {
-				ProjectionViewer pv = (ProjectionViewer) sourceViewer;
+			if (sourceViewer instanceof ProjectionViewer pv) {
 				if (pv.isProjectionMode() != isFoldingEnabled()) {
 					if (pv.canDoOperation(ProjectionViewer.TOGGLE)) {
 						pv.doOperation(ProjectionViewer.TOGGLE);
@@ -733,8 +745,7 @@ public class AntEditor extends TextEditor implements IReconcilingParticipant, IP
 	public AntModel getAntModel() {
 		if (fAntModel == null) {
 			IDocumentProvider provider = getDocumentProvider();
-			if (provider instanceof AntEditorDocumentProvider) {
-				AntEditorDocumentProvider documentProvider = (AntEditorDocumentProvider) provider;
+			if (provider instanceof AntEditorDocumentProvider documentProvider) {
 				fAntModel = documentProvider.getAntModel(getEditorInput());
 			}
 		}
@@ -759,15 +770,15 @@ public class AntEditor extends TextEditor implements IReconcilingParticipant, IP
 	@Override
 	protected void setStatusLineErrorMessage(String msg) {
 		IEditorStatusLine statusLine = getAdapter(IEditorStatusLine.class);
-		if (statusLine != null)
+		if (statusLine != null) {
 			statusLine.setMessage(true, msg, null);
+		}
 	}
 
 	public void openReferenceElement() {
 		ISelection selection = getSelectionProvider().getSelection();
 		Object target = null;
-		if (selection instanceof ITextSelection) {
-			ITextSelection textSelection = (ITextSelection) selection;
+		if (selection instanceof ITextSelection textSelection) {
 			ISourceViewer viewer = getSourceViewer();
 			int textOffset = textSelection.getOffset();
 			IRegion region = XMLTextHover.getRegion(viewer, textOffset);
@@ -1075,8 +1086,7 @@ public class AntEditor extends TextEditor implements IReconcilingParticipant, IP
 		}
 		AntElementNode node = null;
 		ISelection selection = getSelectionProvider().getSelection();
-		if (selection instanceof ITextSelection) {
-			ITextSelection textSelection = (ITextSelection) selection;
+		if (selection instanceof ITextSelection textSelection) {
 			int offset = textSelection.getOffset();
 			node = model.getNode(offset, false);
 		}
@@ -1200,8 +1210,9 @@ public class AntEditor extends TextEditor implements IReconcilingParticipant, IP
 	 */
 	protected void updateOccurrenceAnnotations(ITextSelection selection, AntModel antModel) {
 
-		if (fOccurrencesFinderJob != null)
+		if (fOccurrencesFinderJob != null) {
 			fOccurrencesFinderJob.cancel();
+		}
 
 		if (!fMarkOccurrenceAnnotations) {
 			return;

--- a/ant/org.eclipse.ant.ui/Ant Editor/org/eclipse/ant/internal/ui/editor/AntEditorCompletionProcessor.java
+++ b/ant/org.eclipse.ant.ui/Ant Editor/org/eclipse/ant/internal/ui/editor/AntEditorCompletionProcessor.java
@@ -796,7 +796,7 @@ public class AntEditorCompletionProcessor extends TemplateCompletionProcessor im
 			String deflt = attribute.getDefault();
 			if (deflt != null && deflt.length() > 0) {
 				proposalInfo = (proposalInfo == null ? "<BR><BR>" : (proposalInfo += "<BR><BR>")); //$NON-NLS-1$ //$NON-NLS-2$
-				proposalInfo += MessageFormat.format(AntEditorMessages.getString("AntEditorCompletionProcessor.59"), new Object[] { deflt }); //$NON-NLS-1$
+				proposalInfo += MessageFormat.format(AntEditorMessages.getString("AntEditorCompletionProcessor.59"), deflt); //$NON-NLS-1$
 			}
 
 			ICompletionProposal proposal = new AntCompletionProposal(replacementString, cursorPosition
@@ -820,7 +820,7 @@ public class AntEditorCompletionProcessor extends TemplateCompletionProcessor im
 				continue;
 			}
 			MacroDef.TemplateElement element = elements.get(elementName);
-			String replacementString = MessageFormat.format("<{0}>\n</{1}>", new Object[] { elementName, elementName }); //$NON-NLS-1$
+			String replacementString = MessageFormat.format("<{0}>\n</{1}>", elementName, elementName); //$NON-NLS-1$
 			String proposalInfo = null;
 
 			String description = element.getDescription();
@@ -1823,10 +1823,10 @@ public class AntEditorCompletionProcessor extends TemplateCompletionProcessor im
 		TriggerSequence[] triggers = bindingSvc.getActiveBindingsFor(getContentAssistCommand());
 		String message;
 		if (triggers.length > 0) {
-			message = MessageFormat.format(AntEditorMessages.getString("AntEditorCompletionProcessor.63"), new Object[] { triggers[0].format(), //$NON-NLS-1$
-					showMessage });
+			message = MessageFormat.format(AntEditorMessages.getString("AntEditorCompletionProcessor.63"), triggers[0].format(), //$NON-NLS-1$
+								showMessage);
 		} else {
-			message = MessageFormat.format(AntEditorMessages.getString("AntEditorCompletionProcessor.64"), new Object[] { showMessage }); //$NON-NLS-1$
+			message = MessageFormat.format(AntEditorMessages.getString("AntEditorCompletionProcessor.64"), showMessage); //$NON-NLS-1$
 		}
 		return message;
 	}

--- a/ant/org.eclipse.ant.ui/Ant Editor/org/eclipse/ant/internal/ui/editor/AntSourceViewerInformationControl.java
+++ b/ant/org.eclipse.ant.ui/Ant Editor/org/eclipse/ant/internal/ui/editor/AntSourceViewerInformationControl.java
@@ -77,8 +77,9 @@ public class AntSourceViewerInformationControl implements IInformationControl, I
 
 			@Override
 			public void keyPressed(KeyEvent e) {
-				if (e.character == 0x1B) // ESC
+				if (e.character == 0x1B) { // ESC
 					fShell.dispose();
+				}
 			}
 
 			@Override

--- a/ant/org.eclipse.ant.ui/Ant Editor/org/eclipse/ant/internal/ui/editor/actions/OpenExternalAntDocHandler.java
+++ b/ant/org.eclipse.ant.ui/Ant Editor/org/eclipse/ant/internal/ui/editor/actions/OpenExternalAntDocHandler.java
@@ -47,11 +47,9 @@ public class OpenExternalAntDocHandler extends AbstractHandler {
 	@Override
 	public Object execute(ExecutionEvent event) throws ExecutionException {
 		IEditorPart part = HandlerUtil.getActiveEditor(event);
-		if (part instanceof AntEditor) {
-			AntEditor editor = (AntEditor) part;
+		if (part instanceof AntEditor editor) {
 			ISelection s = HandlerUtil.getCurrentSelection(event);
-			if (s instanceof ITextSelection) {
-				ITextSelection ts = (ITextSelection) s;
+			if (s instanceof ITextSelection ts) {
 				AntModel model = editor.getAntModel();
 				AntElementNode node = null;
 				if (model != null) {
@@ -94,8 +92,7 @@ public class OpenExternalAntDocHandler extends AbstractHandler {
 			} else {
 				pathBuffer.append("using.html#targets"); //$NON-NLS-1$
 			}
-		} else if (node instanceof AntTaskNode) {
-			AntTaskNode taskNode = (AntTaskNode) node;
+		} else if (node instanceof AntTaskNode taskNode) {
 			if (editor.getAntModel().getDefininingTaskNode(taskNode.getTask().getTaskName()) == null) {
 				// not a user defined task
 				appendTaskPath(taskNode, pathBuffer);

--- a/ant/org.eclipse.ant.ui/Ant Editor/org/eclipse/ant/internal/ui/editor/actions/ToggleMarkOccurrencesAction.java
+++ b/ant/org.eclipse.ant.ui/Ant Editor/org/eclipse/ant/internal/ui/editor/actions/ToggleMarkOccurrencesAction.java
@@ -87,7 +87,8 @@ public class ToggleMarkOccurrencesAction extends TextEditorAction implements IPr
 
 	@Override
 	public void propertyChange(PropertyChangeEvent event) {
-		if (event.getProperty().equals(AntEditorPreferenceConstants.EDITOR_MARK_OCCURRENCES))
+		if (event.getProperty().equals(AntEditorPreferenceConstants.EDITOR_MARK_OCCURRENCES)) {
 			setChecked(Boolean.parseBoolean(event.getNewValue().toString()));
+		}
 	}
 }

--- a/ant/org.eclipse.ant.ui/Ant Editor/org/eclipse/ant/internal/ui/editor/formatter/XmlDocumentFormatter.java
+++ b/ant/org.eclipse.ant.ui/Ant Editor/org/eclipse/ant/internal/ui/editor/formatter/XmlDocumentFormatter.java
@@ -232,8 +232,9 @@ public class XmlDocumentFormatter {
 
 				reader.mark(1);
 				int intChar = reader.read();
-				if (intChar == -1)
+				if (intChar == -1) {
 					break;
+				}
 
 				char c = (char) intChar;
 				if (c == '<') {

--- a/ant/org.eclipse.ant.ui/Ant Editor/org/eclipse/ant/internal/ui/editor/formatter/XmlTagFormatter.java
+++ b/ant/org.eclipse.ant.ui/Ant Editor/org/eclipse/ant/internal/ui/editor/formatter/XmlTagFormatter.java
@@ -86,19 +86,22 @@ public class XmlTagFormatter {
 
 		public int minimumLength() {
 			int length = 2; // for the < >
-			if (this.isClosed())
+			if (this.isClosed()) {
 				length++; // if we need to add an />
+			}
 			length += this.getElementName().length();
-			if (this.attributeCount() > 0 || this.isClosed())
+			if (this.attributeCount() > 0 || this.isClosed()) {
 				length++;
+			}
 			for (int i = 0; i < this.attributeCount(); i++) {
 				AttributePair attributePair = this.getAttributePair(i);
 				length += attributePair.getAttribute().length();
 				length += attributePair.getValue().length();
 				length += 4; // equals sign, quote characters & trailing space
 			}
-			if (this.attributeCount() > 0 && !this.isClosed())
+			if (this.attributeCount() > 0 && !this.isClosed()) {
 				length--;
+			}
 			return length;
 		}
 
@@ -120,8 +123,9 @@ public class XmlTagFormatter {
 			StringBuilder sb = new StringBuilder(500);
 			sb.append('<');
 			sb.append(this.getElementName());
-			if (this.attributeCount() > 0 || this.isClosed())
+			if (this.attributeCount() > 0 || this.isClosed()) {
 				sb.append(' ');
+			}
 
 			for (int i = 0; i < this.attributeCount(); i++) {
 				AttributePair attributePair = this.getAttributePair(i);
@@ -130,11 +134,13 @@ public class XmlTagFormatter {
 				sb.append(attributePair.getQuote());
 				sb.append(attributePair.getValue());
 				sb.append(attributePair.getQuote());
-				if (this.isClosed() || i != this.attributeCount() - 1)
+				if (this.isClosed() || i != this.attributeCount() - 1) {
 					sb.append(' ');
+				}
 			}
-			if (this.isClosed())
+			if (this.isClosed()) {
 				sb.append('/');
+			}
 			sb.append('>');
 			return sb.toString();
 		}
@@ -145,8 +151,9 @@ public class XmlTagFormatter {
 		private int countChar(char searchChar, String inTargetString) {
 			StringCharacterIterator iter = new StringCharacterIterator(inTargetString);
 			int i = 0;
-			if (iter.first() == searchChar)
+			if (iter.first() == searchChar) {
 				i++;
+			}
 			while (iter.getIndex() < iter.getEndIndex()) {
 				if (iter.next() == searchChar) {
 					i++;
@@ -216,8 +223,9 @@ public class XmlTagFormatter {
 				sb.append(' ');
 			}
 
-			if (tag.isClosed())
+			if (tag.isClosed()) {
 				sb.append('/');
+			}
 			sb.append('>');
 			return sb.toString();
 		}

--- a/ant/org.eclipse.ant.ui/Ant Editor/org/eclipse/ant/internal/ui/editor/outline/AntEditorContentOutlinePage.java
+++ b/ant/org.eclipse.ant.ui/Ant Editor/org/eclipse/ant/internal/ui/editor/outline/AntEditorContentOutlinePage.java
@@ -98,8 +98,7 @@ public class AntEditorContentOutlinePage extends ContentOutlinePage implements I
 
 		@Override
 		public boolean select(Viewer viewer, Object parentElement, Object element) {
-			if (element instanceof AntElementNode) {
-				AntElementNode node = (AntElementNode) element;
+			if (element instanceof AntElementNode node) {
 				if (fFilterTopLevel && (node instanceof AntTaskNode && parentElement instanceof AntProjectNode)) {
 					return false;
 				}
@@ -438,8 +437,7 @@ public class AntEditorContentOutlinePage extends ContentOutlinePage implements I
 
 	private AntElementNode getSelectedNode() {
 		ISelection iselection = getSelection();
-		if (iselection instanceof IStructuredSelection) {
-			IStructuredSelection selection = (IStructuredSelection) iselection;
+		if (iselection instanceof IStructuredSelection selection) {
 			if (selection.size() == 1) {
 				Object selected = selection.getFirstElement();
 				if (selected instanceof AntElementNode) {
@@ -478,8 +476,7 @@ public class AntEditorContentOutlinePage extends ContentOutlinePage implements I
 	public void select(AntElementNode node) {
 		if (getTreeViewer() != null) {
 			ISelection s = getTreeViewer().getSelection();
-			if (s instanceof IStructuredSelection) {
-				IStructuredSelection ss = (IStructuredSelection) s;
+			if (s instanceof IStructuredSelection ss) {
 				List<?> nodes = ss.toList();
 				if (!nodes.contains(node)) {
 					s = (node == null ? StructuredSelection.EMPTY : new StructuredSelection(node));

--- a/ant/org.eclipse.ant.ui/Ant Editor/org/eclipse/ant/internal/ui/editor/outline/ToggleLinkWithEditorAction.java
+++ b/ant/org.eclipse.ant.ui/Ant Editor/org/eclipse/ant/internal/ui/editor/outline/ToggleLinkWithEditorAction.java
@@ -43,7 +43,8 @@ public class ToggleLinkWithEditorAction extends Action {
 	@Override
 	public void run() {
 		AntUIPlugin.getDefault().getPreferenceStore().setValue(IAntUIPreferenceConstants.OUTLINE_LINK_WITH_EDITOR, isChecked());
-		if (isChecked())
+		if (isChecked()) {
 			fEditor.synchronizeOutlinePage(false);
+		}
 	}
 }

--- a/ant/org.eclipse.ant.ui/Ant Editor/org/eclipse/ant/internal/ui/editor/templates/AntContext.java
+++ b/ant/org.eclipse.ant.ui/Ant Editor/org/eclipse/ant/internal/ui/editor/templates/AntContext.java
@@ -39,8 +39,9 @@ public class AntContext extends DocumentTemplateContext {
 
 	@Override
 	public TemplateBuffer evaluate(Template template) throws BadLocationException, TemplateException {
-		if (!canEvaluate(template))
+		if (!canEvaluate(template)) {
 			return null;
+		}
 
 		TemplateBuffer templateBuffer = createTemplateBuffer(template);
 
@@ -74,8 +75,9 @@ public class AntContext extends DocumentTemplateContext {
 		for (int line = 0; line < lines; line++) {
 			IRegion region = document.getLineInformation(line);
 			String lineDelimiter = document.getLineDelimiter(line);
-			if (lineDelimiter != null)
+			if (lineDelimiter != null) {
 				document.replace(region.getOffset() + region.getLength(), lineDelimiter.length(), defaultLineDelimiter);
+			}
 		}
 	}
 
@@ -99,8 +101,9 @@ public class AntContext extends DocumentTemplateContext {
 		int end = getCompletionOffset() + length;
 
 		try {
-			while (start != end && Character.isWhitespace(document.getChar(end - 1)))
+			while (start != end && Character.isWhitespace(document.getChar(end - 1))) {
 				end--;
+			}
 		}
 		catch (BadLocationException e) {
 			// Return latest valid end

--- a/ant/org.eclipse.ant.ui/Ant Editor/org/eclipse/ant/internal/ui/editor/templates/AntVariableResolver.java
+++ b/ant/org.eclipse.ant.ui/Ant Editor/org/eclipse/ant/internal/ui/editor/templates/AntVariableResolver.java
@@ -34,11 +34,13 @@ public class AntVariableResolver extends TemplateVariableResolver {
 		private int getCommonPrefixLength(String type, String var) {
 			int i = 0;
 			CharSequence vSeq = var.subSequence(2, var.length() - 1); // strip away ${}
-			while (i < type.length() && i < vSeq.length())
-				if (Character.toLowerCase(type.charAt(i)) == Character.toLowerCase(vSeq.charAt(i)))
+			while (i < type.length() && i < vSeq.length()) {
+				if (Character.toLowerCase(type.charAt(i)) == Character.toLowerCase(vSeq.charAt(i))) {
 					i++;
-				else
+				} else {
 					break;
+				}
+			}
 			return i;
 		}
 	};

--- a/ant/org.eclipse.ant.ui/Ant Editor/org/eclipse/ant/internal/ui/editor/text/AntAnnotationModel.java
+++ b/ant/org.eclipse.ant.ui/Ant Editor/org/eclipse/ant/internal/ui/editor/text/AntAnnotationModel.java
@@ -58,8 +58,9 @@ public class AntAnnotationModel extends ResourceMarkerAnnotationModel implements
 		if (start >= 0) {
 			int length = problem.getLength();
 
-			if (length >= 0)
+			if (length >= 0) {
 				return new Position(start, length);
+			}
 		}
 
 		return null;
@@ -113,8 +114,9 @@ public class AntAnnotationModel extends ResourceMarkerAnnotationModel implements
 			}
 		}
 
-		if (temporaryProblemsChanged)
+		if (temporaryProblemsChanged) {
 			fireModelChanged(new AnnotationModelEvent(this));
+		}
 	}
 
 	@Override

--- a/ant/org.eclipse.ant.ui/Ant Editor/org/eclipse/ant/internal/ui/editor/text/AntDocumentSetupParticipant.java
+++ b/ant/org.eclipse.ant.ui/Ant Editor/org/eclipse/ant/internal/ui/editor/text/AntDocumentSetupParticipant.java
@@ -36,8 +36,7 @@ public class AntDocumentSetupParticipant implements IDocumentSetupParticipant {
 
 	@Override
 	public void setup(IDocument document) {
-		if (document instanceof IDocumentExtension3) {
-			IDocumentExtension3 extension3 = (IDocumentExtension3) document;
+		if (document instanceof IDocumentExtension3 extension3) {
 			IDocumentPartitioner partitioner = createDocumentPartitioner();
 			extension3.setDocumentPartitioner(ANT_PARTITIONING, partitioner);
 			partitioner.connect(document);

--- a/ant/org.eclipse.ant.ui/Ant Editor/org/eclipse/ant/internal/ui/editor/text/AntEditorDocumentProvider.java
+++ b/ant/org.eclipse.ant.ui/Ant Editor/org/eclipse/ant/internal/ui/editor/text/AntEditorDocumentProvider.java
@@ -53,8 +53,7 @@ public class AntEditorDocumentProvider extends TextFileDocumentProvider {
 
 	public AntModel getAntModel(Object element) {
 		FileInfo info = getFileInfo(element);
-		if (info instanceof AntFileInfo) {
-			AntFileInfo xmlInfo = (AntFileInfo) info;
+		if (info instanceof AntFileInfo xmlInfo) {
 			return xmlInfo.fAntModel;
 		}
 		return null;
@@ -66,8 +65,8 @@ public class AntEditorDocumentProvider extends TextFileDocumentProvider {
 	}
 
 	protected AntModel createAntModel(Object element, IDocument document, IAnnotationModel annotationModel) {
-		IProblemRequestor requestor = annotationModel instanceof IProblemRequestor ? (IProblemRequestor) annotationModel : null;
-		return new AntModel(document, requestor, new LocationProvider(element instanceof IEditorInput ? (IEditorInput) element : null));
+		IProblemRequestor requestor = annotationModel instanceof IProblemRequestor i ? i : null;
+		return new AntModel(document, requestor, new LocationProvider(element instanceof IEditorInput i ? i : null));
 	}
 
 	@Override
@@ -83,10 +82,10 @@ public class AntEditorDocumentProvider extends TextFileDocumentProvider {
 		// that is setup with the correct document setup participant since it was "missed" by the
 		// document setup extensions (bug 72598).
 		IDocument document = info.fTextFileBuffer.getDocument();
-		if (document instanceof IDocumentExtension3) {
-			IDocumentExtension3 extension = (IDocumentExtension3) document;
-			if (extension.getDocumentPartitioner(AntDocumentSetupParticipant.ANT_PARTITIONING) == null)
+		if (document instanceof IDocumentExtension3 extension) {
+			if (extension.getDocumentPartitioner(AntDocumentSetupParticipant.ANT_PARTITIONING) == null) {
 				fAntDocumentSetupParticipant.setup(document);
+			}
 		}
 
 		// Check if the annotation model has been set by the annotation model factory extension for Ant UI
@@ -118,8 +117,7 @@ public class AntEditorDocumentProvider extends TextFileDocumentProvider {
 
 	@Override
 	protected void disposeFileInfo(Object element, FileInfo info) {
-		if (info instanceof AntFileInfo) {
-			AntFileInfo xmlInfo = (AntFileInfo) info;
+		if (info instanceof AntFileInfo xmlInfo) {
 			if (xmlInfo.fAntModel != null) {
 				IDocument doc = xmlInfo.fTextFileBuffer.getDocument();
 				Object lock = null;

--- a/ant/org.eclipse.ant.ui/Ant Editor/org/eclipse/ant/internal/ui/editor/text/AntExternalAnnotationModel.java
+++ b/ant/org.eclipse.ant.ui/Ant Editor/org/eclipse/ant/internal/ui/editor/text/AntExternalAnnotationModel.java
@@ -73,8 +73,9 @@ public class AntExternalAnnotationModel extends AnnotationModel implements IProb
 			}
 		}
 
-		if (temporaryProblemsChanged)
+		if (temporaryProblemsChanged) {
 			fireModelChanged(new AnnotationModelEvent(this));
+		}
 	}
 
 	protected Position createPositionFromProblem(IProblem problem) {
@@ -82,8 +83,9 @@ public class AntExternalAnnotationModel extends AnnotationModel implements IProb
 		if (start >= 0) {
 			int length = problem.getLength();
 
-			if (length >= 0)
+			if (length >= 0) {
 				return new Position(start, length);
+			}
 		}
 
 		return null;

--- a/ant/org.eclipse.ant.ui/Ant Editor/org/eclipse/ant/internal/ui/editor/text/AntStorageDocumentProvider.java
+++ b/ant/org.eclipse.ant.ui/Ant Editor/org/eclipse/ant/internal/ui/editor/text/AntStorageDocumentProvider.java
@@ -28,8 +28,7 @@ public class AntStorageDocumentProvider extends StorageDocumentProvider {
 	protected void setupDocument(Object element, IDocument document) {
 		if (document != null) {
 			IDocumentPartitioner partitioner = createDocumentPartitioner();
-			if (document instanceof IDocumentExtension3) {
-				IDocumentExtension3 extension3 = (IDocumentExtension3) document;
+			if (document instanceof IDocumentExtension3 extension3) {
 				extension3.setDocumentPartitioner(AntDocumentSetupParticipant.ANT_PARTITIONING, partitioner);
 			} else {
 				document.setDocumentPartitioner(partitioner);

--- a/ant/org.eclipse.ant.ui/Ant Editor/org/eclipse/ant/internal/ui/editor/text/XMLAnnotationHover.java
+++ b/ant/org.eclipse.ant.ui/Ant Editor/org/eclipse/ant/internal/ui/editor/text/XMLAnnotationHover.java
@@ -42,10 +42,12 @@ public class XMLAnnotationHover implements IAnnotationHover {
 		if (position.getOffset() > -1 && position.getLength() > -1) {
 			try {
 				int xmlAnnotationLine = document.getLineOfOffset(position.getOffset());
-				if (line == xmlAnnotationLine)
+				if (line == xmlAnnotationLine) {
 					return 1;
-				if (xmlAnnotationLine <= line && line <= document.getLineOfOffset(position.getOffset() + position.getLength()))
+				}
+				if (xmlAnnotationLine <= line && line <= document.getLineOfOffset(position.getOffset() + position.getLength())) {
 					return 2;
+				}
 			}
 			catch (BadLocationException x) {
 				// do nothing
@@ -63,8 +65,9 @@ public class XMLAnnotationHover implements IAnnotationHover {
 		IDocument document = viewer.getDocument();
 		IAnnotationModel model = viewer.getAnnotationModel();
 
-		if (model == null)
+		if (model == null) {
 			return null;
+		}
 
 		List<Annotation> exact = new ArrayList<>();
 
@@ -72,14 +75,15 @@ public class XMLAnnotationHover implements IAnnotationHover {
 		Map<Position, Object> messagesAtPosition = new HashMap<>();
 		while (e.hasNext()) {
 			Object o = e.next();
-			if (o instanceof Annotation) {
-				Annotation a = (Annotation) o;
+			if (o instanceof Annotation a) {
 				Position position = model.getPosition(a);
-				if (position == null)
+				if (position == null) {
 					continue;
+				}
 
-				if (isDuplicateXMLAnnotation(messagesAtPosition, position, a.getText()))
+				if (isDuplicateXMLAnnotation(messagesAtPosition, position, a.getText())) {
 					continue;
+				}
 
 				switch (compareRulerLine(position, document, line)) {
 					case 1:
@@ -96,8 +100,9 @@ public class XMLAnnotationHover implements IAnnotationHover {
 
 	private boolean isDuplicateXMLAnnotation(Map<Position, Object> messagesAtPosition, Position position, String message) {
 		if (messagesAtPosition.containsKey(position)) {
-			if (message.equals(messagesAtPosition.get(position)))
+			if (message.equals(messagesAtPosition.get(position))) {
 				return true;
+			}
 
 			if (messagesAtPosition.get(position) instanceof List) {
 				@SuppressWarnings("unchecked")
@@ -112,8 +117,9 @@ public class XMLAnnotationHover implements IAnnotationHover {
 				messages.add(message);
 				messagesAtPosition.put(position, messages);
 			}
-		} else
+		} else {
 			messagesAtPosition.put(position, message);
+		}
 		return false;
 	}
 
@@ -177,8 +183,9 @@ public class XMLAnnotationHover implements IAnnotationHover {
 
 		HTMLPrinter.startBulletList(buffer);
 		Iterator<String> e = messages.iterator();
-		while (e.hasNext())
+		while (e.hasNext()) {
 			HTMLPrinter.addBullet(buffer, HTMLPrinter.convertToHTMLContent(e.next()));
+		}
 		HTMLPrinter.endBulletList(buffer);
 
 		HTMLPrinter.addPageEpilog(buffer);

--- a/ant/org.eclipse.ant.ui/Ant Editor/org/eclipse/ant/internal/ui/editor/text/XMLTextHover.java
+++ b/ant/org.eclipse.ant.ui/Ant Editor/org/eclipse/ant/internal/ui/editor/text/XMLTextHover.java
@@ -89,11 +89,10 @@ public class XMLTextHover implements ITextHover, ITextHoverExtension, IInformati
 	@Override
 	public String getHoverInfo(ITextViewer textViewer, IRegion hoverRegion) {
 
-		if (!(textViewer instanceof ISourceViewer)) {
+		if (!(textViewer instanceof ISourceViewer sourceViewer)) {
 			return null;
 		}
 
-		ISourceViewer sourceViewer = (ISourceViewer) textViewer;
 		IAnnotationModel model = sourceViewer.getAnnotationModel();
 
 		if (model != null) {
@@ -238,8 +237,9 @@ public class XMLTextHover implements ITextHover, ITextHoverExtension, IInformati
 			while (pos >= 0) {
 				c = document.getChar(pos);
 				if (c != '.' && c != '-' && c != '/' && c != '\\' && c != ' ' && c != ')' && c != '(' && c != ':'
-						&& !Character.isJavaIdentifierPart(c) && pos != offset)
+						&& !Character.isJavaIdentifierPart(c) && pos != offset) {
 					break;
+				}
 				--pos;
 			}
 
@@ -251,8 +251,9 @@ public class XMLTextHover implements ITextHover, ITextHoverExtension, IInformati
 			while (pos < length) {
 				c = document.getChar(pos);
 				if (c != '.' && c != '-' && c != '/' && c != '\\' && c != ' ' && c != ')' && c != '(' && c != ':'
-						&& !Character.isJavaIdentifierPart(c))
+						&& !Character.isJavaIdentifierPart(c)) {
 					break;
+				}
 				if (c == '/' && (document.getLength() - 1) > (pos + 1) && document.getChar(pos + 1) == '>') {
 					// e.g. <name/>
 					break;

--- a/ant/org.eclipse.ant.ui/Ant Runner Support/org/eclipse/ant/internal/ui/antsupport/inputhandler/AntInputHandler.java
+++ b/ant/org.eclipse.ant.ui/Ant Runner Support/org/eclipse/ant/internal/ui/antsupport/inputhandler/AntInputHandler.java
@@ -66,7 +66,7 @@ public class AntInputHandler extends DefaultInputHandler {
 
 			String initialValue = null;
 			try {
-				request.getClass().getMethod("getDefaultValue", new Class[0]); //$NON-NLS-1$
+				request.getClass().getMethod("getDefaultValue"); //$NON-NLS-1$
 				initialValue = request.getDefaultValue();
 			}
 			catch (SecurityException e1) {

--- a/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/AntImageDescriptor.java
+++ b/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/AntImageDescriptor.java
@@ -61,11 +61,10 @@ public class AntImageDescriptor extends CompositeImageDescriptor {
 
 	@Override
 	public boolean equals(Object object) {
-		if (!(object instanceof AntImageDescriptor)) {
+		if (!(object instanceof AntImageDescriptor other)) {
 			return false;
 		}
 
-		AntImageDescriptor other = (AntImageDescriptor) object;
 		return (getBaseImage().equals(other.getBaseImage()) && getFlags() == other.getFlags());
 	}
 

--- a/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/AntUIPlugin.java
+++ b/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/AntUIPlugin.java
@@ -221,8 +221,9 @@ public class AntUIPlugin extends AbstractUIPlugin {
 	 * @since 3.1
 	 */
 	public synchronized IDocumentProvider getDocumentProvider() {
-		if (fDocumentProvider == null)
+		if (fDocumentProvider == null) {
 			fDocumentProvider = new AntEditorDocumentProvider();
+		}
 		return fDocumentProvider;
 	}
 }

--- a/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/AntUtil.java
+++ b/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/AntUtil.java
@@ -364,7 +364,7 @@ public final class AntUtil {
 	private static String expandVariableString(String variableString, String invalidMessage) throws CoreException {
 		String expandedString = VariablesPlugin.getDefault().getStringVariableManager().performStringSubstitution(variableString);
 		if (expandedString == null || expandedString.length() == 0) {
-			String msg = MessageFormat.format(invalidMessage, new Object[] { variableString });
+			String msg = MessageFormat.format(invalidMessage, variableString);
 			throw new CoreException(new Status(IStatus.ERROR, IAntUIConstants.PLUGIN_ID, 0, msg, null));
 		}
 
@@ -519,11 +519,10 @@ public final class AntUtil {
 			}
 		}
 		catch (PartInitException e) {
-			AntUIPlugin.log(MessageFormat.format(AntUIModelMessages.AntUtil_0, new Object[] { fileResource.getLocation().toOSString() }), e);
+			AntUIPlugin.log(MessageFormat.format(AntUIModelMessages.AntUtil_0, fileResource.getLocation().toOSString()), e);
 		}
 
-		if (editorPart instanceof AntEditor) {
-			AntEditor editor = (AntEditor) editorPart;
+		if (editorPart instanceof AntEditor editor) {
 			if (node.getImportNode() != null) {
 				AntModel model = editor.getAntModel();
 				AntProjectNode project = model.getProjectNode();

--- a/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/ExternalHyperlink.java
+++ b/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/ExternalHyperlink.java
@@ -68,9 +68,7 @@ public class ExternalHyperlink implements IHyperlink {
 		IWorkbenchPage activePage = AntUIPlugin.getActiveWorkbenchWindow().getActivePage();
 		try {
 			IEditorPart editorPart = activePage.openEditor(input, "org.eclipse.ant.ui.internal.editor.AntEditor", true); //$NON-NLS-1$
-			if (fLineNumber > 0 && editorPart instanceof ITextEditor) {
-				ITextEditor textEditor = (ITextEditor) editorPart;
-
+			if (fLineNumber > 0 && editorPart instanceof ITextEditor textEditor) {
 				IDocumentProvider provider = textEditor.getDocumentProvider();
 				try {
 					provider.connect(input);

--- a/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/ImageDescriptorRegistry.java
+++ b/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/ImageDescriptorRegistry.java
@@ -58,17 +58,20 @@ public class ImageDescriptorRegistry {
 	 * @return the image associated with the image descriptor or <code>null</code> if the image descriptor can't create the requested image.
 	 */
 	public Image get(ImageDescriptor descriptor) {
-		if (descriptor == null)
+		if (descriptor == null) {
 			descriptor = ImageDescriptor.getMissingImageDescriptor();
+		}
 
 		Image result = fRegistry.get(descriptor);
-		if (result != null)
+		if (result != null) {
 			return result;
+		}
 
 		Assert.isTrue(fDisplay == AntUIPlugin.getStandardDisplay(), AntUIModelMessages.ImageDescriptorRegistry_Allocating_image_for_wrong_display_1);
 		result = descriptor.createImage();
-		if (result != null)
+		if (result != null) {
 			fRegistry.put(descriptor, result);
+		}
 		return result;
 	}
 

--- a/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/datatransfer/AntBuildfileExportPage.java
+++ b/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/datatransfer/AntBuildfileExportPage.java
@@ -247,14 +247,14 @@ public class AntBuildfileExportPage extends WizardPage {
 				if (projectsWithErrors.size() == 1) {
 					message = DataTransferMessages.AntBuildfileExportPage_cycle_error_in_project;
 				}
-				setErrorMessage(MessageFormat.format(message, new Object[] { ExportUtil.toString(projectsWithErrors, ", ") })); //$NON-NLS-1$
+				setErrorMessage(MessageFormat.format(message, ExportUtil.toString(projectsWithErrors, ", "))); //$NON-NLS-1$
 				complete = false;
 			} else if (projectsWithWarnings.size() > 0) {
 				String message = DataTransferMessages.AntBuildfileExportPage_cycle_warning_in_projects;
 				if (projectsWithWarnings.size() == 1) {
 					message = DataTransferMessages.AntBuildfileExportPage_cycle_warning_in_project;
 				}
-				setMessage(MessageFormat.format(message, new Object[] { ExportUtil.toString(projectsWithWarnings, ", ") }), WARNING); //$NON-NLS-1$
+				setMessage(MessageFormat.format(message, ExportUtil.toString(projectsWithWarnings, ", ")), WARNING); //$NON-NLS-1$
 			} else {
 				setMessage(null);
 			}
@@ -303,7 +303,7 @@ public class AntBuildfileExportPage extends WizardPage {
 		}
 		catch (JavaModelException e) {
 			AntUIPlugin.log(e);
-			setErrorMessage(MessageFormat.format(DataTransferMessages.AntBuildfileExportPage_10, new Object[] { e.toString() }));
+			setErrorMessage(MessageFormat.format(DataTransferMessages.AntBuildfileExportPage_10, e.toString()));
 			return false;
 		}
 		IRunnableWithProgress runnable = pm -> {
@@ -334,7 +334,7 @@ public class AntBuildfileExportPage extends WizardPage {
 
 			if (problem != null) {
 				AntUIPlugin.log(problem);
-				setErrorMessage(MessageFormat.format(DataTransferMessages.AntBuildfileExportPage_10, new Object[] { problem.toString() }));
+				setErrorMessage(MessageFormat.format(DataTransferMessages.AntBuildfileExportPage_10, problem.toString()));
 			}
 		};
 

--- a/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/datatransfer/AntNewJavaProjectPage.java
+++ b/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/datatransfer/AntNewJavaProjectPage.java
@@ -477,8 +477,7 @@ public class AntNewJavaProjectPage extends WizardPage {
 		for (IAntElement node : children) {
 			if (node instanceof AntTargetNode) {
 				getJavacNodes(javacNodes, node);
-			} else if (node instanceof AntTaskNode) {
-				AntTaskNode task = (AntTaskNode) node;
+			} else if (node instanceof AntTaskNode task) {
 				if ("javac".equals(task.getName())) { //$NON-NLS-1$
 					javacNodes.add(task);
 				}

--- a/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/datatransfer/BuildFileCreator.java
+++ b/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/datatransfer/BuildFileCreator.java
@@ -749,8 +749,9 @@ public class BuildFileCreator {
 				classpathRefElement.setAttribute("refid", projectName + ".classpath"); //$NON-NLS-1$ //$NON-NLS-2$
 				javacElement.appendChild(classpathRefElement);
 				element.appendChild(javacElement);
-				if (!JavaRuntime.isModularProject(project))
+				if (!JavaRuntime.isModularProject(project)) {
 					addCompilerBootClasspath(srcDirs, javacElement);
+				}
 			}
 		}
 		root.appendChild(element);

--- a/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/datatransfer/JavacTableLabelProvider.java
+++ b/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/datatransfer/JavacTableLabelProvider.java
@@ -26,11 +26,10 @@ public class JavacTableLabelProvider extends AntModelLabelProvider {
 
 	@Override
 	public StyledString getStyledText(Object element) {
-		if (element instanceof AntElementNode) {
-			AntElementNode node = (AntElementNode) element;
+		if (element instanceof AntElementNode node) {
 			AntElementNode parent = (AntElementNode) node.getParentNode();
 			if (parent != null) {
-				return new StyledString(MessageFormat.format(DataTransferMessages.JavacTableLabelProvider_0, new Object[] { parent.getLabel() }));
+				return new StyledString(MessageFormat.format(DataTransferMessages.JavacTableLabelProvider_0, parent.getLabel()));
 			}
 		}
 		return super.getStyledText(element);

--- a/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/datatransfer/ProjectCreator.java
+++ b/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/datatransfer/ProjectCreator.java
@@ -79,8 +79,7 @@ public class ProjectCreator {
 			}
 		}
 		catch (BuildException be) {
-			IStatus status = new Status(IStatus.ERROR, AntUIPlugin.PI_ANTUI, IStatus.OK, MessageFormat.format(DataTransferMessages.ProjectCreator_0, new Object[] {
-					be.getLocalizedMessage() }), be);
+			IStatus status = new Status(IStatus.ERROR, AntUIPlugin.PI_ANTUI, IStatus.OK, MessageFormat.format(DataTransferMessages.ProjectCreator_0, be.getLocalizedMessage()), be);
 			throw new CoreException(status);
 		}
 	}

--- a/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/datatransfer/SourceAnalyzer.java
+++ b/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/datatransfer/SourceAnalyzer.java
@@ -141,7 +141,7 @@ public class SourceAnalyzer {
 
 	private static void showCycleWarning(String projectName, Shell shell, List<String> cycle, StringBuffer message) {
 
-		String m = MessageFormat.format(DataTransferMessages.SourceAnalyzer_0, new Object[] { projectName });
+		String m = MessageFormat.format(DataTransferMessages.SourceAnalyzer_0, projectName);
 		message.append(m);
 		message.append(ExportUtil.NEWLINE);
 
@@ -164,7 +164,7 @@ public class SourceAnalyzer {
 			for (String requiredSrc : srcdir2sourcedirs.get(srcdir)) {
 				int i = classpath.srcDirs.indexOf(requiredSrc);
 				if (i > classpathIndex) {
-					String s = MessageFormat.format(DataTransferMessages.SourceAnalyzer_3, new Object[] { projectName });
+					String s = MessageFormat.format(DataTransferMessages.SourceAnalyzer_3, projectName);
 					MessageDialog.openWarning(shell, DataTransferMessages.SourceAnalyzer_2, s + ExportUtil.NEWLINE + requiredSrc + " <-> " + srcdir //$NON-NLS-1$
 							+ ExportUtil.NEWLINE);
 					break;

--- a/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/debug/model/AntDebugModelPresentation.java
+++ b/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/debug/model/AntDebugModelPresentation.java
@@ -66,14 +66,11 @@ public class AntDebugModelPresentation extends LabelProvider implements IDebugMo
 
 	@Override
 	public String getText(Object element) {
-		if (element instanceof AntStackFrame) {
-			AntStackFrame frame = (AntStackFrame) element;
+		if (element instanceof AntStackFrame frame) {
 			return getStackFrameText(frame);
-		} else if (element instanceof AntThread) {
-			AntThread thread = (AntThread) element;
+		} else if (element instanceof AntThread thread) {
 			return getThreadText(thread);
-		} else if (element instanceof AntProperty) {
-			AntProperty property = (AntProperty) element;
+		} else if (element instanceof AntProperty property) {
 			return property.getText();
 		} else if (element instanceof AntProperties) {
 			return ((AntProperties) element).getName();
@@ -95,13 +92,11 @@ public class AntDebugModelPresentation extends LabelProvider implements IDebugMo
 					String lineNumber = Integer.toString(marker.getAttribute(IMarker.LINE_NUMBER, -1));
 					String breakpointString = null;
 					if (breakpoint.isRunToLine()) {
-						breakpointString = MessageFormat.format(DebugModelMessages.AntDebugModelPresentation_5, new Object[] { lineNumber,
-								fileName });
+						breakpointString = MessageFormat.format(DebugModelMessages.AntDebugModelPresentation_5, lineNumber, fileName);
 					} else {
-						breakpointString = MessageFormat.format(DebugModelMessages.AntDebugModelPresentation_2, new Object[] { lineNumber,
-								fileName });
+						breakpointString = MessageFormat.format(DebugModelMessages.AntDebugModelPresentation_2, lineNumber, fileName);
 					}
-					text.append(MessageFormat.format(DebugModelMessages.AntDebugModelPresentation_3, new Object[] { breakpointString }));
+					text.append(MessageFormat.format(DebugModelMessages.AntDebugModelPresentation_3, breakpointString));
 				} else {
 					text.append(DebugModelMessages.AntDebugModelPresentation_4);
 				}
@@ -123,7 +118,7 @@ public class AntDebugModelPresentation extends LabelProvider implements IDebugMo
 			} else {
 				lineNumberString = Integer.toString(lineNumber);
 			}
-			text.append(MessageFormat.format(DebugModelMessages.AntDebugModelPresentation_1, new Object[] { lineNumberString }));
+			text.append(MessageFormat.format(DebugModelMessages.AntDebugModelPresentation_1, lineNumberString));
 			return text.toString();
 		}
 		return null;

--- a/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/launchConfigurations/AntLaunchShortcut.java
+++ b/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/launchConfigurations/AntLaunchShortcut.java
@@ -73,8 +73,7 @@ public class AntLaunchShortcut implements ILaunchShortcut2 {
 
 	@Override
 	public void launch(ISelection selection, String mode) {
-		if (selection instanceof IStructuredSelection) {
-			IStructuredSelection structuredSelection = (IStructuredSelection) selection;
+		if (selection instanceof IStructuredSelection structuredSelection) {
 			Object object = structuredSelection.getFirstElement();
 			if (object instanceof IAdaptable) {
 				if (object instanceof AntElementNode) {
@@ -117,8 +116,7 @@ public class AntLaunchShortcut implements ILaunchShortcut2 {
 	 */
 	public void launch(AntElementNode node, String mode) {
 		String selectedTargetName = null;
-		if (node instanceof AntTargetNode) {
-			AntTargetNode targetNode = (AntTargetNode) node;
+		if (node instanceof AntTargetNode targetNode) {
 			if (targetNode.isDefaultTarget()) {
 				selectedTargetName = DEFAULT_TARGET;
 			} else {
@@ -127,8 +125,7 @@ public class AntLaunchShortcut implements ILaunchShortcut2 {
 			}
 		} else if (node instanceof AntProjectNode) {
 			selectedTargetName = DEFAULT_TARGET;
-		} else if (node instanceof AntTaskNode) {
-			AntTaskNode taskNode = (AntTaskNode) node;
+		} else if (node instanceof AntTaskNode taskNode) {
 			selectedTargetName = taskNode.getTask().getOwningTarget().getName();
 		}
 
@@ -316,8 +313,7 @@ public class AntLaunchShortcut implements ILaunchShortcut2 {
 				}
 			}
 			catch (CoreException exception) {
-				reportError(MessageFormat.format(AntLaunchConfigurationMessages.AntLaunchShortcut_Exception_launching, new Object[] {
-						filePath.toFile().getName() }), exception);
+				reportError(MessageFormat.format(AntLaunchConfigurationMessages.AntLaunchShortcut_Exception_launching, filePath.toFile().getName()), exception);
 				return;
 			}
 			launch(mode, configuration);
@@ -404,7 +400,7 @@ public class AntLaunchShortcut implements ILaunchShortcut2 {
 			return workingCopy.doSave();
 		}
 		catch (CoreException e) {
-			reportError(MessageFormat.format(AntLaunchConfigurationMessages.AntLaunchShortcut_2, new Object[] { filePath.toString() }), e);
+			reportError(MessageFormat.format(AntLaunchConfigurationMessages.AntLaunchShortcut_2, filePath.toString()), e);
 		}
 		return null;
 	}
@@ -526,8 +522,7 @@ public class AntLaunchShortcut implements ILaunchShortcut2 {
 
 	@Override
 	public ILaunchConfiguration[] getLaunchConfigurations(ISelection selection) {
-		if (selection instanceof IStructuredSelection) {
-			IStructuredSelection structuredSelection = (IStructuredSelection) selection;
+		if (selection instanceof IStructuredSelection structuredSelection) {
 			Object object = structuredSelection.getFirstElement();
 			if (object instanceof IAdaptable) {
 				if (object instanceof AntElementNode) {
@@ -582,8 +577,7 @@ public class AntLaunchShortcut implements ILaunchShortcut2 {
 
 	@Override
 	public IResource getLaunchableResource(ISelection selection) {
-		if (selection instanceof IStructuredSelection) {
-			IStructuredSelection structuredSelection = (IStructuredSelection) selection;
+		if (selection instanceof IStructuredSelection structuredSelection) {
 			Object object = structuredSelection.getFirstElement();
 			if (object instanceof IAdaptable) {
 				IResource resource = ((IAdaptable) object).getAdapter(IResource.class);

--- a/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/launchConfigurations/AntTabGroup.java
+++ b/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/launchConfigurations/AntTabGroup.java
@@ -41,8 +41,7 @@ public class AntTabGroup extends AbstractLaunchConfigurationTabGroup {
 	public void initializeFrom(ILaunchConfiguration configuration) {
 		try {
 			boolean captureOutput = configuration.getAttribute(IExternalToolConstants.ATTR_CAPTURE_OUTPUT, true);
-			if (!captureOutput && configuration instanceof ILaunchConfigurationWorkingCopy) {
-				ILaunchConfigurationWorkingCopy copy = (ILaunchConfigurationWorkingCopy) configuration;
+			if (!captureOutput && configuration instanceof ILaunchConfigurationWorkingCopy copy) {
 				copy.setAttribute(IExternalToolConstants.ATTR_CAPTURE_OUTPUT, (String) null);
 				copy.setAttribute(DebugPlugin.ATTR_CAPTURE_OUTPUT, false);
 				copy.setAttribute(IDebugUIConstants.ATTR_CAPTURE_IN_CONSOLE, false);
@@ -77,8 +76,7 @@ public class AntTabGroup extends AbstractLaunchConfigurationTabGroup {
 	public void setDefaults(ILaunchConfigurationWorkingCopy configuration) {
 		// set default name for script
 		IResource resource = DebugUITools.getSelectedResource();
-		if (resource != null && resource instanceof IFile) {
-			IFile file = (IFile) resource;
+		if (resource != null && resource instanceof IFile file) {
 			if (AntUtil.isKnownAntFile(file)) {
 				String projectName = file.getProject().getName();
 				StringBuilder buffer = new StringBuilder(projectName);

--- a/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/launchConfigurations/AntTargetsTab.java
+++ b/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/launchConfigurations/AntTargetsTab.java
@@ -390,8 +390,7 @@ public class AntTargetsTab extends AbstractLaunchConfigurationTab {
 
 		fTableViewer.addDoubleClickListener(event -> {
 			ISelection selection = event.getSelection();
-			if (!selection.isEmpty() && selection instanceof IStructuredSelection) {
-				IStructuredSelection ss = (IStructuredSelection) selection;
+			if (!selection.isEmpty() && selection instanceof IStructuredSelection ss) {
 				Object element = ss.getFirstElement();
 				boolean checked = !fTableViewer.getChecked(element);
 				fTableViewer.setChecked(element, checked);
@@ -467,11 +466,9 @@ public class AntTargetsTab extends AbstractLaunchConfigurationTab {
 		String total = Integer.toString(visible);
 		int numHidden = all - visible;
 		if (numHidden > 0) {
-			fSelectionCountLabel.setText(MessageFormat.format(AntLaunchConfigurationMessages.AntTargetsTab_13, new Object[] { numSelected,
-					String.valueOf(all), String.valueOf(numHidden) }));
+			fSelectionCountLabel.setText(MessageFormat.format(AntLaunchConfigurationMessages.AntTargetsTab_13, numSelected, String.valueOf(all), String.valueOf(numHidden)));
 		} else {
-			fSelectionCountLabel.setText(MessageFormat.format(AntLaunchConfigurationMessages.AntTargetsTab__0__out_of__1__selected_7, new Object[] {
-					numSelected, total }));
+			fSelectionCountLabel.setText(MessageFormat.format(AntLaunchConfigurationMessages.AntTargetsTab__0__out_of__1__selected_7, numSelected, total));
 		}
 
 		fOrderButton.setEnabled(checked.length > 1);

--- a/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/launchConfigurations/AntWorkingDirectoryBlock.java
+++ b/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/launchConfigurations/AntWorkingDirectoryBlock.java
@@ -62,8 +62,7 @@ public class AntWorkingDirectoryBlock extends JavaWorkingDirectoryBlock {
 			}
 		}
 		catch (CoreException e) {
-			setErrorMessage(MessageFormat.format(AntLaunchConfigurationMessages.AntWorkingDirectoryBlock_0, new Object[] {
-					e.getStatus().getMessage() }));
+			setErrorMessage(MessageFormat.format(AntLaunchConfigurationMessages.AntWorkingDirectoryBlock_0, e.getStatus().getMessage()));
 			AntUIPlugin.log(e);
 		}
 	}

--- a/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/model/AntElementAdapterFactory.java
+++ b/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/model/AntElementAdapterFactory.java
@@ -24,8 +24,7 @@ public class AntElementAdapterFactory implements IAdapterFactory {
 	@SuppressWarnings("unchecked")
 	@Override
 	public <T> T getAdapter(Object adaptableObject, Class<T> adapterType) {
-		if (adaptableObject instanceof AntElementNode) {
-			AntElementNode node = (AntElementNode) adaptableObject;
+		if (adaptableObject instanceof AntElementNode node) {
 			if (IResource.class.equals(adapterType)) {
 				return (T) node.getIFile();
 			}

--- a/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/model/AntElementNode.java
+++ b/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/model/AntElementNode.java
@@ -357,11 +357,10 @@ public class AntElementNode implements IAdaptable, IAntElement {
 		if (!(o1 instanceof AntElementNode || o2 instanceof AntElementNode)) {
 			return o2.equals(o1);
 		}
-		if (!(o1 instanceof AntElementNode && o2 instanceof AntElementNode)) {
+		if (!(o1 instanceof AntElementNode e1 && o2 instanceof AntElementNode)) {
 			return false;
 		}
 
-		AntElementNode e1 = (AntElementNode) o1;
 		AntElementNode e2 = (AntElementNode) o2;
 
 		return e1.getElementPath().equals(e2.getElementPath());
@@ -446,10 +445,10 @@ public class AntElementNode implements IAdaptable, IAntElement {
 		String path = getFilePath();
 
 		if (getImportNode() != null) {
-			displayName.append(MessageFormat.format(AntModelMessages.AntElementNode_9, new Object[] { getImportNode().getLabel() }));
+			displayName.append(MessageFormat.format(AntModelMessages.AntElementNode_9, getImportNode().getLabel()));
 		} else {
 			String entityName = getAntModel().getEntityName(path);
-			displayName.append(MessageFormat.format(AntModelMessages.AntElementNode_9, new Object[] { entityName }));
+			displayName.append(MessageFormat.format(AntModelMessages.AntElementNode_9, entityName));
 		}
 	}
 

--- a/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/model/AntModel.java
+++ b/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/model/AntModel.java
@@ -589,7 +589,7 @@ public class AntModel implements IAntModel {
 		String defaultTargetName = fProjectNode.getDefaultTargetName();
 		if (defaultTargetName != null && fProjectNode.getProject().getTargets().get(defaultTargetName) == null) {
 			// no default target when one specified (default target does not have to be specified)
-			String message = MessageFormat.format(AntModelMessages.AntModel_43, new Object[] { defaultTargetName });
+			String message = MessageFormat.format(AntModelMessages.AntModel_43, defaultTargetName);
 			IProblem problem = createProblem(message, fProjectNode.getOffset(), fProjectNode.getSelectionLength(), AntModelProblem.SEVERITY_ERROR);
 			acceptProblem(problem);
 			markHierarchy(fProjectNode, AntModelProblem.SEVERITY_ERROR, message);
@@ -617,7 +617,7 @@ public class AntModel implements IAntModel {
 	private void checkMissingDependencies(IAntElement node, IAntElement originalNode) {
 		String missing = ((AntTargetNode) node).checkDependencies();
 		if (missing != null) {
-			String message = MessageFormat.format(AntModelMessages.AntModel_44, new Object[] { missing });
+			String message = MessageFormat.format(AntModelMessages.AntModel_44, missing);
 			IAntElement importNode = node.getImportNode();
 			if (importNode != null) {
 				node = importNode;
@@ -1313,8 +1313,7 @@ public class AntModel implements IAntModel {
 		}
 		markHierarchy(node, severity, exception.getMessage());
 
-		if (exception instanceof SAXParseException) {
-			SAXParseException parseException = (SAXParseException) exception;
+		if (exception instanceof SAXParseException parseException) {
 			if (node.getOffset() == -1) {
 				computeEndLocationForErrorNode(node, parseException.getLineNumber() - 1, parseException.getColumnNumber());
 			} else {
@@ -1413,8 +1412,7 @@ public class AntModel implements IAntModel {
 		if (projectNode.hasChildren()) {
 			List<IAntElement> possibleTargets = projectNode.getChildNodes();
 			for (IAntElement node : possibleTargets) {
-				if (node instanceof AntTargetNode) {
-					AntTargetNode targetNode = (AntTargetNode) node;
+				if (node instanceof AntTargetNode targetNode) {
 					if (targetName.equalsIgnoreCase(targetNode.getTarget().getName())) {
 						return targetNode;
 					}
@@ -1593,8 +1591,7 @@ public class AntModel implements IAntModel {
 		Set<Task> nodes = fTaskToNode.keySet();
 		for (Task task : nodes) {
 			Task tmptask = task;
-			if (tmptask instanceof UnknownElement) {
-				UnknownElement element = (UnknownElement) tmptask;
+			if (tmptask instanceof UnknownElement element) {
 				RuntimeConfigurable wrapper = element.getWrapper();
 				Map<String, Object> attributes = wrapper.getAttributeMap();
 				String id = (String) attributes.get("id"); //$NON-NLS-1$

--- a/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/model/AntModelContentProvider.java
+++ b/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/model/AntModelContentProvider.java
@@ -34,8 +34,7 @@ public class AntModelContentProvider implements ITreeContentProvider {
 
 	@Override
 	public Object[] getChildren(Object parentNode) {
-		if (parentNode instanceof AntElementNode) {
-			AntElementNode parentElement = (AntElementNode) parentNode;
+		if (parentNode instanceof AntElementNode parentElement) {
 			if (parentElement.hasChildren()) {
 				List<IAntElement> children = parentElement.getChildNodes();
 				return children.toArray();

--- a/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/model/AntModelCore.java
+++ b/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/model/AntModelCore.java
@@ -81,8 +81,7 @@ public class AntModelCore implements IBreakpointsListener {
 					IMarker marker = breakpoint.getMarker();
 					if (marker.exists()) {
 						int lineNumber = marker.getAttribute(IMarker.LINE_NUMBER, 0);
-						marker.setAttribute(IMarker.MESSAGE, MessageFormat.format(DebugModelMessages.AntLineBreakpoint_0, new Object[] {
-								Integer.toString(lineNumber) }));
+						marker.setAttribute(IMarker.MESSAGE, MessageFormat.format(DebugModelMessages.AntLineBreakpoint_0, Integer.toString(lineNumber)));
 					}
 				}
 			}

--- a/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/model/AntModelLabelProvider.java
+++ b/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/model/AntModelLabelProvider.java
@@ -70,14 +70,11 @@ public class AntModelLabelProvider extends StyledCellLabelProvider implements IC
 
 	@Override
 	public StyledString getStyledText(Object element) {
-		if (element instanceof AntTargetNode) {
-			AntTargetNode node = (AntTargetNode) element;
+		if (element instanceof AntTargetNode node) {
 			return new StyledString(node.getLabel());
-		} else if (element instanceof AntTaskNode) {
-			AntTaskNode node = (AntTaskNode) element;
+		} else if (element instanceof AntTaskNode node) {
 			return new StyledString(node.getLabel());
-		} else if (element instanceof AntProjectNodeProxy) {
-			AntProjectNodeProxy node = (AntProjectNodeProxy) element;
+		} else if (element instanceof AntProjectNodeProxy node) {
 			StyledString buff = new StyledString(node.getLabel());
 			IFile buildfile = node.getBuildFileResource();
 			if (buildfile != null) {

--- a/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/model/AntModelProject.java
+++ b/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/model/AntModelProject.java
@@ -140,8 +140,7 @@ public class AntModelProject extends Project {
 		T ref = super.getReference(key);/* references.get(key); */
 		if (ref == null) {
 			ref = (T) idrefs.get(key);
-			if (ref instanceof UnknownElement) {
-				UnknownElement ue = (UnknownElement) ref;
+			if (ref instanceof UnknownElement ue) {
 				ue.maybeConfigure();
 				return (T) ue.getRealThing();
 			}

--- a/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/preferences/AbstractAntEditorPreferencePage.java
+++ b/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/preferences/AbstractAntEditorPreferencePage.java
@@ -218,11 +218,12 @@ public abstract class AbstractAntEditorPreferencePage extends PreferencePage imp
 		} else {
 			try {
 				int value = Integer.parseInt(number);
-				if (value < 0)
-					status.setError(MessageFormat.format(errorMessages[1], new Object[] { number }));
+				if (value < 0) {
+					status.setError(MessageFormat.format(errorMessages[1], number));
+				}
 			}
 			catch (NumberFormatException e) {
-				status.setError(MessageFormat.format(errorMessages[1], new Object[] { number }));
+				status.setError(MessageFormat.format(errorMessages[1], number));
 			}
 		}
 		return status;

--- a/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/preferences/AddCustomDialog.java
+++ b/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/preferences/AddCustomDialog.java
@@ -165,8 +165,7 @@ public class AddCustomDialog extends StatusDialog {
 			file.close();
 		}
 		catch (IOException e) {
-			AntUIPlugin.log(MessageFormat.format(AntPreferencesMessages.AddCustomDialog_Could_not_close_zip_file__0__4, new Object[] {
-					file.getName() }), e);
+			AntUIPlugin.log(MessageFormat.format(AntPreferencesMessages.AddCustomDialog_Could_not_close_zip_file__0__4, file.getName()), e);
 			return false;
 		}
 
@@ -237,7 +236,7 @@ public class AddCustomDialog extends StatusDialog {
 		} else if (!editing) {
 			for (String aName : existingNames) {
 				if (aName.equals(customName)) {
-					status.setError(MessageFormat.format(alreadyExistsErrorMsg, new Object[] { customName }));
+					status.setError(MessageFormat.format(alreadyExistsErrorMsg, customName));
 					updateStatus(status);
 					return;
 				}
@@ -473,8 +472,7 @@ public class AddCustomDialog extends StatusDialog {
 		return new WorkbenchContentProvider() {
 			@Override
 			public Object[] getChildren(Object o) {
-				if (o instanceof MinimizedFileSystemElement) {
-					MinimizedFileSystemElement element = (MinimizedFileSystemElement) o;
+				if (o instanceof MinimizedFileSystemElement element) {
 					return element.getFiles(currentProvider).toArray();
 				}
 				return new Object[0];
@@ -489,8 +487,7 @@ public class AddCustomDialog extends StatusDialog {
 		return new WorkbenchContentProvider() {
 			@Override
 			public Object[] getChildren(Object o) {
-				if (o instanceof MinimizedFileSystemElement) {
-					MinimizedFileSystemElement element = (MinimizedFileSystemElement) o;
+				if (o instanceof MinimizedFileSystemElement element) {
 					return element.getFolders(currentProvider).toArray();
 				}
 				return new Object[0];
@@ -498,8 +495,7 @@ public class AddCustomDialog extends StatusDialog {
 
 			@Override
 			public boolean hasChildren(Object o) {
-				if (o instanceof MinimizedFileSystemElement) {
-					MinimizedFileSystemElement element = (MinimizedFileSystemElement) o;
+				if (o instanceof MinimizedFileSystemElement element) {
 					if (element.isPopulated()) {
 						return getChildren(element).length > 0;
 					}

--- a/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/preferences/AntClasspathBlock.java
+++ b/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/preferences/AntClasspathBlock.java
@@ -375,8 +375,7 @@ public class AntClasspathBlock {
 			while (selected.hasNext()) {
 				IClasspathEntry element = (IClasspathEntry) selected.next();
 
-				if (element instanceof GlobalClasspathEntries) {
-					GlobalClasspathEntries global = (GlobalClasspathEntries) element;
+				if (element instanceof GlobalClasspathEntries global) {
 					canRemove = global.canBeRemoved();
 					canAdd = global.getType() != ClasspathModel.CONTRIBUTED;
 					canMove = false;

--- a/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/preferences/AntClasspathContentProvider.java
+++ b/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/preferences/AntClasspathContentProvider.java
@@ -45,8 +45,7 @@ public class AntClasspathContentProvider implements ITreeContentProvider {
 				added = false;
 			}
 			parent = model;
-		} else if (parent instanceof GlobalClasspathEntries) {
-			GlobalClasspathEntries globalParent = (GlobalClasspathEntries) parent;
+		} else if (parent instanceof GlobalClasspathEntries globalParent) {
 			newEntry = model.createEntry(child, globalParent);
 			ClasspathEntry newClasspathEntry = (ClasspathEntry) newEntry;
 			if (!globalParent.contains(newClasspathEntry)) {
@@ -187,8 +186,7 @@ public class AntClasspathContentProvider implements ITreeContentProvider {
 	}
 
 	public void setEntries(IClasspathEntry currentParent, List<IAntClasspathEntry> entries) {
-		if (currentParent instanceof GlobalClasspathEntries) {
-			GlobalClasspathEntries group = (GlobalClasspathEntries) currentParent;
+		if (currentParent instanceof GlobalClasspathEntries group) {
 			group.setEntries(entries);
 		}
 

--- a/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/preferences/AntClasspathLabelProvider.java
+++ b/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/preferences/AntClasspathLabelProvider.java
@@ -51,8 +51,7 @@ public class AntClasspathLabelProvider implements ILabelProvider {
 	@Override
 	public Image getImage(Object element) {
 		String file;
-		if (element instanceof ClasspathEntry) {
-			ClasspathEntry entry = (ClasspathEntry) element;
+		if (element instanceof ClasspathEntry entry) {
 			if (entry.isEclipseRuntimeRequired()) {
 				return AntUIImages.getImage(IAntUIConstants.IMG_ANT_ECLIPSE_RUNTIME_OBJECT);
 			}
@@ -68,8 +67,7 @@ public class AntClasspathLabelProvider implements ILabelProvider {
 
 	@Override
 	public String getText(Object element) {
-		if (element instanceof IAntClasspathEntry) {
-			IAntClasspathEntry entry = (IAntClasspathEntry) element;
+		if (element instanceof IAntClasspathEntry entry) {
 			StringBuilder label = new StringBuilder(entry.getLabel());
 			if (element instanceof GlobalClasspathEntries) {
 				if (((GlobalClasspathEntries) element).getType() == ClasspathModel.ANT_HOME) {

--- a/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/preferences/AntEditorPreferencePage.java
+++ b/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/preferences/AntEditorPreferencePage.java
@@ -722,10 +722,11 @@ public class AntEditorPreferencePage extends AbstractAntEditorPreferencePage {
 		link.addSelectionListener(new SelectionAdapter() {
 			@Override
 			public void widgetSelected(SelectionEvent e) {
-				if ("org.eclipse.ui.preferencePages.GeneralTextEditor".equals(e.text)) //$NON-NLS-1$
+				if ("org.eclipse.ui.preferencePages.GeneralTextEditor".equals(e.text)) { //$NON-NLS-1$
 					PreferencesUtil.createPreferenceDialogOn(link.getShell(), e.text, null, null);
-				else if ("org.eclipse.ui.preferencePages.ColorsAndFonts".equals(e.text)) //$NON-NLS-1$
+				} else if ("org.eclipse.ui.preferencePages.ColorsAndFonts".equals(e.text)) { //$NON-NLS-1$
 					PreferencesUtil.createPreferenceDialogOn(link.getShell(), e.text, null, "selectFont:org.eclipse.jface.textfont"); //$NON-NLS-1$
+				}
 			}
 		});
 		String linktooltip = AntPreferencesMessages.AntEditorPreferencePage_3;

--- a/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/preferences/AntObjectLabelProvider.java
+++ b/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/preferences/AntObjectLabelProvider.java
@@ -41,14 +41,12 @@ public class AntObjectLabelProvider extends LabelProvider implements ITableLabel
 		if (columnIndex != 0) {
 			return null;
 		}
-		if (element instanceof Property) {
-			Property prop = (Property) element;
+		if (element instanceof Property prop) {
 			if (prop.isDefault() && prop.isEclipseRuntimeRequired()) {
 				return AntUIImages.getImage(IAntUIConstants.IMG_ANT_ECLIPSE_RUNTIME_OBJECT);
 			}
 			return getPropertyImage();
-		} else if (element instanceof AntObject) {
-			AntObject object = (AntObject) element;
+		} else if (element instanceof AntObject object) {
 			if (object.isDefault() && object.isEclipseRuntimeRequired()) {
 				return AntUIImages.getImage(IAntUIConstants.IMG_ANT_ECLIPSE_RUNTIME_OBJECT);
 			}
@@ -64,8 +62,7 @@ public class AntObjectLabelProvider extends LabelProvider implements ITableLabel
 	public String getColumnText(Object element, int columnIndex) {
 		if (element instanceof Property) {
 			return getPropertyText((Property) element, columnIndex);
-		} else if (element instanceof AntObject) {
-			AntObject object = (AntObject) element;
+		} else if (element instanceof AntObject object) {
 			switch (columnIndex) {
 				case 0:
 					return object.toString();

--- a/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/preferences/AntPage.java
+++ b/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/preferences/AntPage.java
@@ -420,8 +420,7 @@ public abstract class AntPage {
 		Iterator<?> itr = newSelection.iterator();
 		while (itr.hasNext()) {
 			Object element = itr.next();
-			if (element instanceof AntObject) {
-				AntObject antObject = (AntObject) element;
+			if (element instanceof AntObject antObject) {
 				if (antObject.isDefault()) {
 					enabled = false;
 					break;

--- a/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/preferences/AntPreferencePage.java
+++ b/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/preferences/AntPreferencePage.java
@@ -144,8 +144,7 @@ public class AntPreferencePage extends FieldEditorPreferencePage implements IWor
 		int maxValue = 1200000;
 		timeout.setValidRange(minValue, maxValue);
 		timeout.setValidateStrategy(StringFieldEditor.VALIDATE_ON_KEY_STROKE);
-		timeout.setErrorMessage(MessageFormat.format(AntPreferencesMessages.AntPreferencePage_14, new Object[] { Integer.valueOf(minValue),
-				Integer.valueOf(maxValue) }));
+		timeout.setErrorMessage(MessageFormat.format(AntPreferencesMessages.AntPreferencePage_14, Integer.valueOf(minValue), Integer.valueOf(maxValue)));
 		addField(timeout);
 
 		editor = new URLFieldEditor(IAntUIPreferenceConstants.DOCUMENTATION_URL, AntPreferencesMessages.AntPreferencePage_2, getFieldEditorParent());

--- a/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/preferences/AntPreviewerUpdater.java
+++ b/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/preferences/AntPreviewerUpdater.java
@@ -151,13 +151,15 @@ class AntPreviewerUpdater {
 
 		if (store.contains(key)) {
 
-			if (store.isDefault(key))
+			if (store.isDefault(key)) {
 				rgb = PreferenceConverter.getDefaultColor(store, key);
-			else
+			} else {
 				rgb = PreferenceConverter.getColor(store, key);
+			}
 
-			if (rgb != null)
+			if (rgb != null) {
 				return new Color(display, rgb);
+			}
 		}
 
 		return null;

--- a/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/preferences/AntPropertiesBlock.java
+++ b/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/preferences/AntPropertiesBlock.java
@@ -491,12 +491,10 @@ public class AntPropertiesBlock {
 			String propertyName = property.getName();
 			if (propertyName.equals(name)) {
 				if (property.isDefault()) {
-					MessageDialog.openError(propertyTableViewer.getControl().getShell(), AntPreferencesMessages.AntPropertiesBlock_17, MessageFormat.format(AntPreferencesMessages.AntPropertiesBlock_18, new Object[] {
-							propertyName, property.getPluginLabel() }));
+					MessageDialog.openError(propertyTableViewer.getControl().getShell(), AntPreferencesMessages.AntPropertiesBlock_17, MessageFormat.format(AntPreferencesMessages.AntPropertiesBlock_18, propertyName, property.getPluginLabel()));
 					return false;
 				}
-				boolean overWrite = MessageDialog.openQuestion(propertyTableViewer.getControl().getShell(), AntPreferencesMessages.AntPropertiesBlock_15, MessageFormat.format(AntPreferencesMessages.AntPropertiesBlock_16, new Object[] {
-						name }));
+				boolean overWrite = MessageDialog.openQuestion(propertyTableViewer.getControl().getShell(), AntPreferencesMessages.AntPropertiesBlock_15, MessageFormat.format(AntPreferencesMessages.AntPropertiesBlock_16, name));
 				if (!overWrite) {
 					return false;
 				}
@@ -524,8 +522,7 @@ public class AntPropertiesBlock {
 		Iterator<Object> itr = newSelection.iterator();
 		while (itr.hasNext()) {
 			Object element = itr.next();
-			if (element instanceof Property) {
-				Property property = (Property) element;
+			if (element instanceof Property property) {
 				if (property.isDefault()) {
 					enabled = false;
 					break;

--- a/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/preferences/ClasspathEntry.java
+++ b/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/preferences/ClasspathEntry.java
@@ -42,8 +42,7 @@ public class ClasspathEntry extends AbstractClasspathEntry {
 
 	@Override
 	public boolean equals(Object obj) {
-		if (obj instanceof IAntClasspathEntry) {
-			IAntClasspathEntry other = (IAntClasspathEntry) obj;
+		if (obj instanceof IAntClasspathEntry other) {
 			return other.getLabel().equals(getLabel());
 		}
 		return false;

--- a/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/preferences/FileFilter.java
+++ b/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/preferences/FileFilter.java
@@ -83,8 +83,7 @@ public class FileFilter extends ViewerFilter {
 		boolean added = false;
 		try {
 			for (IResource resource : container.members()) {
-				if (resource instanceof IFile) {
-					IFile file = (IFile) resource;
+				if (resource instanceof IFile file) {
 					String ext = file.getFileExtension();
 					if (!fConsiderExtension || canAccept(ext)) {
 						set.add(file);

--- a/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/preferences/OverlayPreferenceStore.java
+++ b/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/preferences/OverlayPreferenceStore.java
@@ -50,8 +50,9 @@ class OverlayPreferenceStore implements IPreferenceStore {
 		@Override
 		public void propertyChange(PropertyChangeEvent event) {
 			OverlayKey key = findOverlayKey(event.getProperty());
-			if (key != null)
+			if (key != null) {
 				propagateProperty(fParent, key, fStore);
+			}
 		}
 	}
 
@@ -69,8 +70,9 @@ class OverlayPreferenceStore implements IPreferenceStore {
 
 	private OverlayKey findOverlayKey(String key) {
 		for (OverlayKey overlayKey : fOverlayKeys) {
-			if (overlayKey.fKey.equals(key))
+			if (overlayKey.fKey.equals(key)) {
 				return overlayKey;
+			}
 		}
 		return null;
 	}
@@ -82,8 +84,9 @@ class OverlayPreferenceStore implements IPreferenceStore {
 	private void propagateProperty(IPreferenceStore orgin, OverlayKey key, IPreferenceStore target) {
 
 		if (orgin.isDefault(key.fKey)) {
-			if (!target.isDefault(key.fKey))
+			if (!target.isDefault(key.fKey)) {
 				target.setToDefault(key.fKey);
+			}
 			return;
 		}
 
@@ -92,93 +95,106 @@ class OverlayPreferenceStore implements IPreferenceStore {
 
 			boolean originValue = orgin.getBoolean(key.fKey);
 			boolean targetValue = target.getBoolean(key.fKey);
-			if (targetValue != originValue)
+			if (targetValue != originValue) {
 				target.setValue(key.fKey, originValue);
+			}
 
 		} else if (DOUBLE == d) {
 
 			double originValue = orgin.getDouble(key.fKey);
 			double targetValue = target.getDouble(key.fKey);
-			if (targetValue != originValue)
+			if (targetValue != originValue) {
 				target.setValue(key.fKey, originValue);
+			}
 
 		} else if (FLOAT == d) {
 
 			float originValue = orgin.getFloat(key.fKey);
 			float targetValue = target.getFloat(key.fKey);
-			if (targetValue != originValue)
+			if (targetValue != originValue) {
 				target.setValue(key.fKey, originValue);
+			}
 
 		} else if (INT == d) {
 
 			int originValue = orgin.getInt(key.fKey);
 			int targetValue = target.getInt(key.fKey);
-			if (targetValue != originValue)
+			if (targetValue != originValue) {
 				target.setValue(key.fKey, originValue);
+			}
 
 		} else if (LONG == d) {
 
 			long originValue = orgin.getLong(key.fKey);
 			long targetValue = target.getLong(key.fKey);
-			if (targetValue != originValue)
+			if (targetValue != originValue) {
 				target.setValue(key.fKey, originValue);
+			}
 
 		} else if (STRING == d) {
 
 			String originValue = orgin.getString(key.fKey);
 			String targetValue = target.getString(key.fKey);
-			if (targetValue != null && originValue != null && !targetValue.equals(originValue))
+			if (targetValue != null && originValue != null && !targetValue.equals(originValue)) {
 				target.setValue(key.fKey, originValue);
+			}
 
 		}
 	}
 
 	public void propagate() {
-		for (OverlayKey key : fOverlayKeys)
+		for (OverlayKey key : fOverlayKeys) {
 			propagateProperty(fStore, key, fParent);
+		}
 	}
 
 	private void loadProperty(IPreferenceStore orgin, OverlayKey key, IPreferenceStore target, boolean forceInitialization) {
 		TypeDescriptor d = key.fDescriptor;
 		if (BOOLEAN == d) {
 
-			if (forceInitialization)
+			if (forceInitialization) {
 				target.setValue(key.fKey, true);
+			}
 			target.setValue(key.fKey, orgin.getBoolean(key.fKey));
 			target.setDefault(key.fKey, orgin.getDefaultBoolean(key.fKey));
 
 		} else if (DOUBLE == d) {
 
-			if (forceInitialization)
+			if (forceInitialization) {
 				target.setValue(key.fKey, 1.0D);
+			}
 			target.setValue(key.fKey, orgin.getDouble(key.fKey));
 			target.setDefault(key.fKey, orgin.getDefaultDouble(key.fKey));
 
 		} else if (FLOAT == d) {
 
-			if (forceInitialization)
+			if (forceInitialization) {
 				target.setValue(key.fKey, 1.0F);
+			}
 			target.setValue(key.fKey, orgin.getFloat(key.fKey));
 			target.setDefault(key.fKey, orgin.getDefaultFloat(key.fKey));
 
 		} else if (INT == d) {
 
-			if (forceInitialization)
+			if (forceInitialization) {
 				target.setValue(key.fKey, 1);
+			}
 			target.setValue(key.fKey, orgin.getInt(key.fKey));
 			target.setDefault(key.fKey, orgin.getDefaultInt(key.fKey));
 
 		} else if (LONG == d) {
 
-			if (forceInitialization)
+			if (forceInitialization) {
 				target.setValue(key.fKey, 1L);
+			}
 			target.setValue(key.fKey, orgin.getLong(key.fKey));
 			target.setDefault(key.fKey, orgin.getDefaultLong(key.fKey));
 
 		} else if (STRING == d) {
 
-			if (forceInitialization)
+			if (forceInitialization) {
 				target.setValue(key.fKey, "1"); //$NON-NLS-1$
+			}
 			target.setValue(key.fKey, orgin.getString(key.fKey));
 			target.setDefault(key.fKey, orgin.getDefaultString(key.fKey));
 
@@ -186,13 +202,15 @@ class OverlayPreferenceStore implements IPreferenceStore {
 	}
 
 	public void load() {
-		for (OverlayKey key : fOverlayKeys)
+		for (OverlayKey key : fOverlayKeys) {
 			loadProperty(fParent, key, fStore, true);
+		}
 	}
 
 	public void loadDefaults() {
-		for (OverlayKey key : fOverlayKeys)
+		for (OverlayKey key : fOverlayKeys) {
 			setToDefault(key.fKey);
+		}
 	}
 
 	public void start() {
@@ -301,44 +319,51 @@ class OverlayPreferenceStore implements IPreferenceStore {
 
 	@Override
 	public void putValue(String name, String value) {
-		if (covers(name))
+		if (covers(name)) {
 			fStore.putValue(name, value);
+		}
 	}
 
 	@Override
 	public void setDefault(String name, double value) {
-		if (covers(name))
+		if (covers(name)) {
 			fStore.setDefault(name, value);
+		}
 	}
 
 	@Override
 	public void setDefault(String name, float value) {
-		if (covers(name))
+		if (covers(name)) {
 			fStore.setDefault(name, value);
+		}
 	}
 
 	@Override
 	public void setDefault(String name, int value) {
-		if (covers(name))
+		if (covers(name)) {
 			fStore.setDefault(name, value);
+		}
 	}
 
 	@Override
 	public void setDefault(String name, long value) {
-		if (covers(name))
+		if (covers(name)) {
 			fStore.setDefault(name, value);
+		}
 	}
 
 	@Override
 	public void setDefault(String name, String value) {
-		if (covers(name))
+		if (covers(name)) {
 			fStore.setDefault(name, value);
+		}
 	}
 
 	@Override
 	public void setDefault(String name, boolean value) {
-		if (covers(name))
+		if (covers(name)) {
 			fStore.setDefault(name, value);
+		}
 	}
 
 	@Override
@@ -348,37 +373,43 @@ class OverlayPreferenceStore implements IPreferenceStore {
 
 	@Override
 	public void setValue(String name, double value) {
-		if (covers(name))
+		if (covers(name)) {
 			fStore.setValue(name, value);
+		}
 	}
 
 	@Override
 	public void setValue(String name, float value) {
-		if (covers(name))
+		if (covers(name)) {
 			fStore.setValue(name, value);
+		}
 	}
 
 	@Override
 	public void setValue(String name, int value) {
-		if (covers(name))
+		if (covers(name)) {
 			fStore.setValue(name, value);
+		}
 	}
 
 	@Override
 	public void setValue(String name, long value) {
-		if (covers(name))
+		if (covers(name)) {
 			fStore.setValue(name, value);
+		}
 	}
 
 	@Override
 	public void setValue(String name, String value) {
-		if (covers(name))
+		if (covers(name)) {
 			fStore.setValue(name, value);
+		}
 	}
 
 	@Override
 	public void setValue(String name, boolean value) {
-		if (covers(name))
+		if (covers(name)) {
 			fStore.setValue(name, value);
+		}
 	}
 }

--- a/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/refactoring/LaunchConfigurationBuildfileChange.java
+++ b/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/refactoring/LaunchConfigurationBuildfileChange.java
@@ -189,13 +189,12 @@ public class LaunchConfigurationBuildfileChange extends Change {
 	@Override
 	public String getName() {
 		if (fNewLaunchConfigurationName != null) {
-			return MessageFormat.format(RefactoringMessages.LaunchConfigurationBuildfileChange_0, new Object[] { fLaunchConfiguration.getName(),
-					fNewLaunchConfigurationName });
+			return MessageFormat.format(RefactoringMessages.LaunchConfigurationBuildfileChange_0, fLaunchConfiguration.getName(), fNewLaunchConfigurationName);
 		}
 		if (fNewProjectName == null) {
-			return MessageFormat.format(RefactoringMessages.LaunchConfigurationBuildfileChange_1, new Object[] { fLaunchConfiguration.getName() });
+			return MessageFormat.format(RefactoringMessages.LaunchConfigurationBuildfileChange_1, fLaunchConfiguration.getName());
 		}
-		return MessageFormat.format(RefactoringMessages.LaunchConfigurationBuildfileChange_2, new Object[] { fLaunchConfiguration.getName() });
+		return MessageFormat.format(RefactoringMessages.LaunchConfigurationBuildfileChange_2, fLaunchConfiguration.getName());
 	}
 
 	@Override
@@ -213,14 +212,11 @@ public class LaunchConfigurationBuildfileChange extends Change {
 				if (fOldProjectName.equals(projectName)) {
 					return new RefactoringStatus();
 				}
-				return RefactoringStatus.createWarningStatus(MessageFormat.format(RefactoringMessages.LaunchConfigurationBuildfileChange_4, new Object[] {
-						fLaunchConfiguration.getName(), fOldProjectName }));
+				return RefactoringStatus.createWarningStatus(MessageFormat.format(RefactoringMessages.LaunchConfigurationBuildfileChange_4, fLaunchConfiguration.getName(), fOldProjectName));
 			}
-			return RefactoringStatus.createWarningStatus(MessageFormat.format(RefactoringMessages.LaunchConfigurationBuildfileChange_5, new Object[] {
-					fLaunchConfiguration.getName(), fOldBuildfileLocation }));
+			return RefactoringStatus.createWarningStatus(MessageFormat.format(RefactoringMessages.LaunchConfigurationBuildfileChange_5, fLaunchConfiguration.getName(), fOldBuildfileLocation));
 		}
-		return RefactoringStatus.createFatalErrorStatus(MessageFormat.format(RefactoringMessages.LaunchConfigurationBuildfileChange_6, new Object[] {
-				fLaunchConfiguration.getName() }));
+		return RefactoringStatus.createFatalErrorStatus(MessageFormat.format(RefactoringMessages.LaunchConfigurationBuildfileChange_6, fLaunchConfiguration.getName()));
 	}
 
 	@Override

--- a/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/views/AntView.java
+++ b/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/views/AntView.java
@@ -362,8 +362,7 @@ public class AntView extends ViewPart implements IResourceChangeListener, IShowI
 	 * Returns text appropriate for display in the workbench status line for the given node.
 	 */
 	private String getStatusLineText(AntElementNode node) {
-		if (node instanceof AntProjectNode) {
-			AntProjectNode project = (AntProjectNode) node;
+		if (node instanceof AntProjectNode project) {
 			StringBuilder message = new StringBuilder(project.getBuildFileName());
 			String description = project.getDescription();
 			if (description != null && description.length() > 0) {
@@ -371,8 +370,7 @@ public class AntView extends ViewPart implements IResourceChangeListener, IShowI
 				message.append(description);
 			}
 			return message.toString();
-		} else if (node instanceof AntTargetNode) {
-			AntTargetNode target = (AntTargetNode) node;
+		} else if (node instanceof AntTargetNode target) {
 			StringBuilder message = new StringBuilder();
 			Enumeration<String> depends = target.getTarget().getDependencies();
 			if (depends.hasMoreElements()) {
@@ -656,8 +654,7 @@ public class AntView extends ViewPart implements IResourceChangeListener, IShowI
 		IStructuredSelection selection = (IStructuredSelection) getViewer().getSelection();
 		if (selection.size() == 1) {
 			Object element = selection.getFirstElement();
-			if (element instanceof AntElementNode) {
-				AntElementNode node = (AntElementNode) element;
+			if (element instanceof AntElementNode node) {
 				return node;
 			}
 		}

--- a/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/views/actions/AntOpenWithMenu.java
+++ b/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/views/actions/AntOpenWithMenu.java
@@ -257,8 +257,7 @@ public class AntOpenWithMenu extends ContributionItem {
 							IDE.openEditor(fPage, fileResource, true);
 						}
 						catch (PartInitException e) {
-							AntUIPlugin.log(MessageFormat.format(AntViewActionMessages.AntViewOpenWithMenu_Editor_failed, new Object[] {
-									fileResource.getLocation().toOSString() }), e);
+							AntUIPlugin.log(MessageFormat.format(AntViewActionMessages.AntViewOpenWithMenu_Editor_failed, fileResource.getLocation().toOSString()), e);
 						}
 					}
 					break;

--- a/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/views/actions/CollapseAllHandler.java
+++ b/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/views/actions/CollapseAllHandler.java
@@ -31,8 +31,7 @@ public class CollapseAllHandler extends AbstractHandler {
 	@Override
 	public Object execute(ExecutionEvent event) throws ExecutionException {
 		IWorkbenchPart part = HandlerUtil.getActivePart(event);
-		if (part instanceof AntView) {
-			AntView view = (AntView) part;
+		if (part instanceof AntView view) {
 			TreeViewer viewer = view.getViewer();
 			try {
 				viewer.getTree().setRedraw(false);

--- a/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/views/actions/RefreshBuildFilesAction.java
+++ b/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/views/actions/RefreshBuildFilesAction.java
@@ -74,8 +74,7 @@ public class RefreshBuildFilesAction extends Action implements IUpdate {
 				AntProjectNodeProxy project;
 				while (iter.hasNext()) {
 					project = (AntProjectNodeProxy) iter.next();
-					monitor.subTask(MessageFormat.format(AntViewActionMessages.RefreshBuildFilesAction_Refreshing__0__4, new Object[] {
-							project.getBuildFileName() }));
+					monitor.subTask(MessageFormat.format(AntViewActionMessages.RefreshBuildFilesAction_Refreshing__0__4, project.getBuildFileName()));
 					project.parseBuildFile(true);
 					monitor.worked(1);
 				}

--- a/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/views/actions/SearchForBuildFilesAction.java
+++ b/ant/org.eclipse.ant.ui/Ant Tools Support/org/eclipse/ant/internal/ui/views/actions/SearchForBuildFilesAction.java
@@ -60,8 +60,7 @@ public class SearchForBuildFilesAction extends Action {
 						monitor.beginTask(AntViewActionMessages.SearchForBuildFilesAction_Processing_search_results_3, files.length);
 						for (int i = 0; i < files.length && !monitor.isCanceled(); i++) {
 							String buildFileName = files[i].getFullPath().toString();
-							monitor.subTask(MessageFormat.format(AntViewActionMessages.SearchForBuildFilesAction_Adding__0__4, new Object[] {
-									buildFileName }));
+							monitor.subTask(MessageFormat.format(AntViewActionMessages.SearchForBuildFilesAction_Adding__0__4, buildFileName));
 							if (alreadyAdded(buildFileName)) {
 								// Don't parse projects that have already been added.
 								continue;

--- a/ant/org.eclipse.ant.ui/Remote Ant Support/org/eclipse/ant/internal/ui/antsupport/inputhandler/SWTInputHandler.java
+++ b/ant/org.eclipse.ant.ui/Remote Ant Support/org/eclipse/ant/internal/ui/antsupport/inputhandler/SWTInputHandler.java
@@ -87,8 +87,9 @@ public class SWTInputHandler extends DefaultInputHandler {
 		fDialog.open();
 
 		while (!fDialog.isDisposed()) {
-			if (!fDialog.getDisplay().readAndDispatch())
+			if (!fDialog.getDisplay().readAndDispatch()) {
 				fDialog.getDisplay().sleep();
+			}
 		}
 		Display.getDefault().dispose();
 	}
@@ -133,7 +134,7 @@ public class SWTInputHandler extends DefaultInputHandler {
 
 		String value = null;
 		try {
-			fRequest.getClass().getMethod("getDefaultValue", new Class<?>[0]); //$NON-NLS-1$
+			fRequest.getClass().getMethod("getDefaultValue"); //$NON-NLS-1$
 			value = fRequest.getDefaultValue();
 		}
 		catch (SecurityException e) {


### PR DESCRIPTION
### The following cleanups where applied:

- Add final modifier to private fields
- Add missing '<span>@</span>Deprecated' annotations
- Add missing '<span>@</span>Override' annotations
- Add missing '<span>@</span>Override' annotations to implementations of interface methods
- Convert control statement bodies to block
- Make inner classes static where possible
- Remove unnecessary array creation for varargs
- Remove unnecessary suppress warning tokens
- Replace deprecated calls with inlined content where possible
- Use pattern matching for instanceof

