### PR TITLE
Clean Code for debug/org.eclipse.core.externaltools

### DIFF
--- a/debug/org.eclipse.core.externaltools/src/org/eclipse/core/externaltools/internal/model/BuilderCoreUtils.java
+++ b/debug/org.eclipse.core.externaltools/src/org/eclipse/core/externaltools/internal/model/BuilderCoreUtils.java
@@ -202,8 +202,7 @@ public class BuilderCoreUtils {
 			}
 		} else {
 			ILaunchConfiguration temp = config;
-			if (config instanceof ILaunchConfigurationWorkingCopy) {
-				ILaunchConfigurationWorkingCopy workingCopy = (ILaunchConfigurationWorkingCopy) config;
+			if (config instanceof ILaunchConfigurationWorkingCopy workingCopy) {
 				if (workingCopy.getOriginal() != null) {
 					temp = workingCopy.getOriginal();
 				}


### PR DESCRIPTION
### The following cleanups where applied:

- Add final modifier to private fields
- Add missing '<span>@</span>Deprecated' annotations
- Add missing '<span>@</span>Override' annotations
- Add missing '<span>@</span>Override' annotations to implementations of interface methods
- Convert control statement bodies to block
- Make inner classes static where possible
- Remove unnecessary array creation for varargs
- Remove unnecessary suppress warning tokens
- Replace deprecated calls with inlined content where possible
- Use pattern matching for instanceof

