### PR TITLE
Clean Code for debug/org.eclipse.core.variables

### DIFF
--- a/debug/org.eclipse.core.variables/src/org/eclipse/core/internal/variables/ContributedValueVariable.java
+++ b/debug/org.eclipse.core.variables/src/org/eclipse/core/internal/variables/ContributedValueVariable.java
@@ -85,8 +85,7 @@ public class ContributedValueVariable extends StringVariable implements IValueVa
 				if (className != null) {
 					try {
 						Object object = getConfigurationElement().createExecutableExtension("initializerClass"); //$NON-NLS-1$
-						if (object instanceof IValueVariableInitializer) {
-							IValueVariableInitializer initializer = (IValueVariableInitializer)object;
+						if (object instanceof IValueVariableInitializer initializer) {
 							initializer.initialize(this);
 						} else {
 							VariablesPlugin.logMessage(NLS.bind("Unable to initialize variable {0} - initializer must be an instance of IValueVariableInitializer.", new String[]{getName()}), null); //$NON-NLS-1$

--- a/debug/org.eclipse.core.variables/src/org/eclipse/core/internal/variables/StringVariableManager.java
+++ b/debug/org.eclipse.core.variables/src/org/eclipse/core/internal/variables/StringVariableManager.java
@@ -232,8 +232,7 @@ public class StringVariableManager implements IStringVariableManager, IPreferenc
 			if (old != null) {
 				DynamicVariable oldVariable = (DynamicVariable)old;
 				VariablesPlugin.logMessage(NLS.bind("Dynamic variable extension from bundle ''{0}'' overrides existing extension variable ''{1}'' from bundle ''{2}''", //$NON-NLS-1$
-						new String[] {element.getDeclaringExtension().getContributor().getName(),oldVariable.getName(),
-							oldVariable.getConfigurationElement().getDeclaringExtension().getContributor().getName()}), null);
+						element.getDeclaringExtension().getContributor().getName(), oldVariable.getName(), oldVariable.getConfigurationElement().getDeclaringExtension().getContributor().getName()), null);
 			}
 		}
 	}
@@ -258,8 +257,7 @@ public class StringVariableManager implements IStringVariableManager, IPreferenc
 			if (old != null) {
 				StringVariable oldVariable = (StringVariable)old;
 				VariablesPlugin.logMessage(NLS.bind("Contributed variable extension from bundle ''{0}'' overrides existing extension variable ''{1}'' from  bundle ''{2}''", //$NON-NLS-1$
-						new String[] {element.getDeclaringExtension().getContributor().getName(),oldVariable.getName(),
-							oldVariable.getConfigurationElement().getDeclaringExtension().getContributor().getName()}), null);
+						element.getDeclaringExtension().getContributor().getName(), oldVariable.getName(), oldVariable.getConfigurationElement().getDeclaringExtension().getContributor().getName()), null);
 			}
 		}
 	}


### PR DESCRIPTION
### The following cleanups where applied:

- Add final modifier to private fields
- Add missing '<span>@</span>Deprecated' annotations
- Add missing '<span>@</span>Override' annotations
- Add missing '<span>@</span>Override' annotations to implementations of interface methods
- Convert control statement bodies to block
- Make inner classes static where possible
- Remove unnecessary array creation for varargs
- Remove unnecessary suppress warning tokens
- Replace deprecated calls with inlined content where possible
- Use pattern matching for instanceof

