### PR TITLE
Clean Code for debug/org.eclipse.debug.core

### DIFF
--- a/.github/workflows/doCleanCode.yml
+++ b/.github/workflows/doCleanCode.yml
@@ -1,0 +1,17 @@
+name: Perform Code Clean
+concurrency: 
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+on:
+  workflow_dispatch:
+
+jobs:
+  clean-code:
+    uses: laeubi/eclipse.platform.releng.aggregator/.github/workflows/cleanCode.yml@limit_number_of_cleanup_prs
+    with:
+      author: Eclipse Platform Bot <platform-bot@eclipse.org>
+      do-quickfix: false
+      do-cleanups: true
+      bundle-folders: ant/*/ debug/*/ resources/bundles/*/ runtime/bundles/*/ team/bundles/*/ ua/*/ update/*/ platform/*/
+    secrets:
+      token: ${{ secrets.PLATFORM_BOT_PAT }}

--- a/debug/org.eclipse.debug.core/core/org/eclipse/debug/core/DebugPlugin.java
+++ b/debug/org.eclipse.debug.core/core/org/eclipse/debug/core/DebugPlugin.java
@@ -692,7 +692,7 @@ public class DebugPlugin extends Plugin {
 				if (handler instanceof IStatusHandler) {
 					return (IStatusHandler)handler;
 				}
-				invalidStatusHandler(null, MessageFormat.format("Registered status handler {0} does not implement required interface IStatusHandler.", new Object[] { config.getDeclaringExtension().getUniqueIdentifier() })); //$NON-NLS-1$
+				invalidStatusHandler(null, MessageFormat.format("Registered status handler {0} does not implement required interface IStatusHandler.", config.getDeclaringExtension().getUniqueIdentifier())); //$NON-NLS-1$
 			} catch (CoreException e) {
 				log(e);
 			}
@@ -1140,7 +1140,7 @@ public class DebugPlugin extends Plugin {
 		if (getDefault().isDebugging()) {
 			// this message is intentionally not externalized, as an exception may
 			// be due to the resource bundle itself
-			log(new Status(IStatus.ERROR, getUniqueIdentifier(), ERROR, MessageFormat.format(DebugCoreMessages.DebugPlugin_2, new Object[] { message }), null));
+			log(new Status(IStatus.ERROR, getUniqueIdentifier(), ERROR, MessageFormat.format(DebugCoreMessages.DebugPlugin_2, message), null));
 		}
 	}
 
@@ -1216,8 +1216,7 @@ public class DebugPlugin extends Plugin {
 			} else {
 				// invalid process factory
 				String badDefiner = configurationElement.getContributor().getName();
-				log(new Status(IStatus.ERROR, DebugPlugin.PI_DEBUG_CORE, ERROR, MessageFormat.format(DebugCoreMessages.DebugPlugin_4, new Object[] {
-					badDefiner, id }), null));
+				log(new Status(IStatus.ERROR, DebugPlugin.PI_DEBUG_CORE, ERROR, MessageFormat.format(DebugCoreMessages.DebugPlugin_4, badDefiner, id), null));
 			}
 		}
 	}
@@ -1238,15 +1237,13 @@ public class DebugPlugin extends Plugin {
 					try {
 						priority = Integer.parseInt(attribute);
 					} catch (NumberFormatException e) {
-						log(new Status(IStatus.ERROR, DebugPlugin.PI_DEBUG_CORE, ERROR, MessageFormat.format(DebugCoreMessages.DebugPlugin_invalid_exec_factory, new Object[] {
-								configurationElement.getContributor().getName() }), null));
+						log(new Status(IStatus.ERROR, DebugPlugin.PI_DEBUG_CORE, ERROR, MessageFormat.format(DebugCoreMessages.DebugPlugin_invalid_exec_factory, configurationElement.getContributor().getName()), null));
 						priority = 0;
 					}
 					list.add(new ExecFactoryFacade(configurationElement, priority));
 				} else {
 					String badDefiner = configurationElement.getContributor().getName();
-					log(new Status(IStatus.ERROR, DebugPlugin.PI_DEBUG_CORE, ERROR, MessageFormat.format(DebugCoreMessages.DebugPlugin_invalid_exec_factory, new Object[] {
-							badDefiner }), null));
+					log(new Status(IStatus.ERROR, DebugPlugin.PI_DEBUG_CORE, ERROR, MessageFormat.format(DebugCoreMessages.DebugPlugin_invalid_exec_factory, badDefiner), null));
 				}
 			}
 			list.sort(Comparator.comparingInt(ExecFactoryFacade::getPriority).reversed());
@@ -1256,7 +1253,7 @@ public class DebugPlugin extends Plugin {
 	}
 
 	private void invalidStatusHandler(Exception e, String id) {
-		log(new Status(IStatus.ERROR, DebugPlugin.PI_DEBUG_CORE, ERROR, MessageFormat.format(DebugCoreMessages.DebugPlugin_5, new Object[] { id }), e));
+		log(new Status(IStatus.ERROR, DebugPlugin.PI_DEBUG_CORE, ERROR, MessageFormat.format(DebugCoreMessages.DebugPlugin_5, id), e));
 	}
 
 	/**
@@ -1286,7 +1283,7 @@ public class DebugPlugin extends Plugin {
 		}
 	}
 
-	private class ExecFactoryFacade implements ExecFactory {
+	private static class ExecFactoryFacade implements ExecFactory {
 
 		private IConfigurationElement element;
 		private int priority;

--- a/debug/org.eclipse.debug.core/core/org/eclipse/debug/core/model/LaunchConfigurationDelegate.java
+++ b/debug/org.eclipse.debug.core/core/org/eclipse/debug/core/model/LaunchConfigurationDelegate.java
@@ -163,7 +163,7 @@ public abstract class LaunchConfigurationDelegate implements ILaunchConfiguratio
 			monitor.subTask(DebugCoreMessages.LaunchConfigurationDelegate_6);
 			List<IAdaptable> errors = new ArrayList<>();
 			for (IProject project : projects) {
-				monitor.subTask(MessageFormat.format(DebugCoreMessages.LaunchConfigurationDelegate_7, new Object[] { project.getName() }));
+				monitor.subTask(MessageFormat.format(DebugCoreMessages.LaunchConfigurationDelegate_7, project.getName()));
 				if (existsProblems(project)) {
 					errors.add(project);
 				}

--- a/debug/org.eclipse.debug.core/core/org/eclipse/debug/core/model/MemoryByte.java
+++ b/debug/org.eclipse.debug.core/core/org/eclipse/debug/core/model/MemoryByte.java
@@ -157,8 +157,9 @@ public class MemoryByte {
 	 */
 	public void setReadable(boolean readable) {
 		flags |= MemoryByte.READABLE;
-		if (!readable)
+		if (!readable) {
 			flags ^= MemoryByte.READABLE;
+		}
 	}
 
 	/**
@@ -179,8 +180,9 @@ public class MemoryByte {
 	 */
 	public void setWritable(boolean writable) {
 		flags |= MemoryByte.WRITABLE;
-		if (!writable)
+		if (!writable) {
 			flags ^= MemoryByte.WRITABLE;
+		}
 	}
 
 	/**
@@ -199,8 +201,9 @@ public class MemoryByte {
 	 */
 	public void setChanged(boolean changed) {
 		flags |= MemoryByte.CHANGED;
-		if (!changed)
+		if (!changed) {
 			flags ^= MemoryByte.CHANGED;
+		}
 	}
 
 	/**
@@ -220,8 +223,9 @@ public class MemoryByte {
 	 */
 	public void setHistoryKnown(boolean known) {
 		flags |= MemoryByte.HISTORY_KNOWN;
-		if (!known)
+		if (!known) {
 			flags ^= MemoryByte.HISTORY_KNOWN;
+		}
 	}
 
 	/**
@@ -242,8 +246,9 @@ public class MemoryByte {
 	public void setBigEndian(boolean isBigEndian)
 	{
 		flags |= MemoryByte.BIG_ENDIAN;
-		if (!isBigEndian)
+		if (!isBigEndian) {
 			flags ^= MemoryByte.BIG_ENDIAN;
+		}
 	}
 
 	/**
@@ -266,8 +271,9 @@ public class MemoryByte {
 	public void setEndianessKnown(boolean isEndianessKnown)
 	{
 		flags |= MemoryByte.ENDIANESS_KNOWN;
-		if (!isEndianessKnown)
+		if (!isEndianessKnown) {
 			flags ^= MemoryByte.ENDIANESS_KNOWN;
+		}
 	}
 
 	/**

--- a/debug/org.eclipse.debug.core/core/org/eclipse/debug/core/sourcelookup/AbstractSourceLookupDirector.java
+++ b/debug/org.eclipse.debug.core/core/org/eclipse/debug/core/sourcelookup/AbstractSourceLookupDirector.java
@@ -261,7 +261,7 @@ public abstract class AbstractSourceLookupDirector implements ISourceLookupDirec
 				containers.add(container);
 			}
 			else {
-				abort(MessageFormat.format(SourceLookupMessages.AbstractSourceLookupDirector_12, new Object[] { typeId }), null);
+				abort(MessageFormat.format(SourceLookupMessages.AbstractSourceLookupDirector_12, typeId), null);
 			}
 		}
 		return containers;

--- a/debug/org.eclipse.debug.core/core/org/eclipse/debug/core/sourcelookup/containers/ExternalArchiveSourceContainer.java
+++ b/debug/org.eclipse.debug.core/core/org/eclipse/debug/core/sourcelookup/containers/ExternalArchiveSourceContainer.java
@@ -239,9 +239,9 @@ public class ExternalArchiveSourceContainer extends AbstractSourceContainer {
 		} catch (IOException e) {
 			File file = new File(fArchivePath);
 			if (file.exists()) {
-				abort(MessageFormat.format(SourceLookupMessages.ExternalArchiveSourceContainer_2, new Object[] { fArchivePath }), e);
+				abort(MessageFormat.format(SourceLookupMessages.ExternalArchiveSourceContainer_2, fArchivePath), e);
 			} else {
-				warn(MessageFormat.format(SourceLookupMessages.ExternalArchiveSourceContainer_1, new Object[] { fArchivePath }), e);
+				warn(MessageFormat.format(SourceLookupMessages.ExternalArchiveSourceContainer_1, fArchivePath), e);
 			}
 		}
 		return null;

--- a/debug/org.eclipse.debug.core/core/org/eclipse/debug/internal/core/BreakpointManager.java
+++ b/debug/org.eclipse.debug.core/core/org/eclipse/debug/internal/core/BreakpointManager.java
@@ -555,7 +555,7 @@ public class BreakpointManager implements IBreakpointManager, IResourceChangeLis
 			IConfigurationElement config = fBreakpointExtensions.get(marker.getType());
 			if (config == null) {
 				throw new DebugException(new Status(IStatus.ERROR, DebugPlugin.getUniqueIdentifier(),
- DebugException.CONFIGURATION_INVALID, MessageFormat.format(DebugCoreMessages.BreakpointManager_Missing_breakpoint_definition, new Object[] { marker.getType() }), null));
+ DebugException.CONFIGURATION_INVALID, MessageFormat.format(DebugCoreMessages.BreakpointManager_Missing_breakpoint_definition, marker.getType()), null));
 			}
 			Object object = config.createExecutableExtension(IConfigurationElementConstants.CLASS);
 			if (object instanceof IBreakpoint) {

--- a/debug/org.eclipse.debug.core/core/org/eclipse/debug/internal/core/ExpressionManager.java
+++ b/debug/org.eclipse.debug.core/core/org/eclipse/debug/internal/core/ExpressionManager.java
@@ -165,7 +165,7 @@ public class ExpressionManager extends PlatformObject implements IExpressionMana
 			if (node.getNodeType() == Node.ELEMENT_NODE) {
 				Element element= (Element) node;
 				if (!element.getNodeName().equals(EXPRESSION_TAG)) {
-					DebugPlugin.logMessage(MessageFormat.format("Invalid XML element encountered while loading watch expressions: {0}", new Object[] { node.getNodeName() }), null); //$NON-NLS-1$
+					DebugPlugin.logMessage(MessageFormat.format("Invalid XML element encountered while loading watch expressions: {0}", node.getNodeName()), null); //$NON-NLS-1$
 					continue;
 				}
 				String expressionText= element.getAttribute(TEXT_TAG);

--- a/debug/org.eclipse.debug.core/core/org/eclipse/debug/internal/core/LaunchConfigurationInfo.java
+++ b/debug/org.eclipse.debug.core/core/org/eclipse/debug/internal/core/LaunchConfigurationInfo.java
@@ -832,12 +832,11 @@ public class LaunchConfigurationInfo {
 	public boolean equals(Object obj) {
 
 		// Make sure it's a LaunchConfigurationInfo object
-		if (!(obj instanceof LaunchConfigurationInfo)) {
+		if (!(obj instanceof LaunchConfigurationInfo other)) {
 			return false;
 		}
 
 		// Make sure the types are the same
-		LaunchConfigurationInfo other = (LaunchConfigurationInfo) obj;
 		if (!fType.getIdentifier().equals(other.getType().getIdentifier())) {
 			return false;
 		}

--- a/debug/org.eclipse.debug.core/core/org/eclipse/debug/internal/core/LaunchConfigurationWorkingCopy.java
+++ b/debug/org.eclipse.debug.core/core/org/eclipse/debug/internal/core/LaunchConfigurationWorkingCopy.java
@@ -245,7 +245,7 @@ public class LaunchConfigurationWorkingCopy extends LaunchConfiguration implemen
 	 * @throws CoreException if a problem is encountered
 	 */
 	private void doSave0(IProgressMonitor monitor) throws CoreException {
-		SubMonitor lmonitor = SubMonitor.convert(monitor, MessageFormat.format(DebugCoreMessages.LaunchConfigurationWorkingCopy_0, new Object[] { getName() }), 2);
+		SubMonitor lmonitor = SubMonitor.convert(monitor, MessageFormat.format(DebugCoreMessages.LaunchConfigurationWorkingCopy_0, getName()), 2);
 		try {
 			// set up from/to information if this is a move
 			boolean moved = (!isNew() && isMoved());
@@ -286,7 +286,7 @@ public class LaunchConfigurationWorkingCopy extends LaunchConfiguration implemen
 			throw new DebugException(
 					new Status(
 						IStatus.ERROR, DebugPlugin.getUniqueIdentifier(),
- DebugException.REQUEST_FAILED, MessageFormat.format(DebugCoreMessages.LaunchConfigurationWorkingCopy__0__occurred_generating_launch_configuration_XML__1, new Object[] { e.toString() }), null
+ DebugException.REQUEST_FAILED, MessageFormat.format(DebugCoreMessages.LaunchConfigurationWorkingCopy__0__occurred_generating_launch_configuration_XML__1, e.toString()), null
 						)
 					);
 		}
@@ -322,7 +322,7 @@ public class LaunchConfigurationWorkingCopy extends LaunchConfiguration implemen
 					throw new DebugException(
 						new Status(
 						 IStatus.ERROR, DebugPlugin.getUniqueIdentifier(),
- DebugException.REQUEST_FAILED, MessageFormat.format(DebugCoreMessages.LaunchConfigurationWorkingCopy__0__occurred_generating_launch_configuration_XML__1, new Object[] { ie.toString() }), null
+ DebugException.REQUEST_FAILED, MessageFormat.format(DebugCoreMessages.LaunchConfigurationWorkingCopy__0__occurred_generating_launch_configuration_XML__1, ie.toString()), null
 						)
 					);
 				}
@@ -353,7 +353,7 @@ public class LaunchConfigurationWorkingCopy extends LaunchConfiguration implemen
 						added = true;
 						//create file input stream: work one unit in a sub monitor
 						smonitor = lmonitor.newChild(1);
-						smonitor.setTaskName(MessageFormat.format(DebugCoreMessages.LaunchConfigurationWorkingCopy_2, new Object[] { getName() }));
+						smonitor.setTaskName(MessageFormat.format(DebugCoreMessages.LaunchConfigurationWorkingCopy_2, getName()));
 						file.create(stream, false, smonitor);
 					} else {
 						// validate edit
@@ -366,7 +366,7 @@ public class LaunchConfigurationWorkingCopy extends LaunchConfiguration implemen
 						}
 						//set the contents of the file: work 1 unit in a sub monitor
 						smonitor = lmonitor.newChild(1);
-						smonitor.setTaskName(MessageFormat.format(DebugCoreMessages.LaunchConfigurationWorkingCopy_3, new Object[] { getName() }));
+						smonitor.setTaskName(MessageFormat.format(DebugCoreMessages.LaunchConfigurationWorkingCopy_3, getName()));
 						file.setContents(stream, true, false, smonitor);
 					}
 				} catch (IOException closeException) {

--- a/debug/org.eclipse.debug.core/core/org/eclipse/debug/internal/core/LaunchDelegate.java
+++ b/debug/org.eclipse.debug.core/core/org/eclipse/debug/internal/core/LaunchDelegate.java
@@ -91,7 +91,7 @@ public final class LaunchDelegate implements ILaunchDelegate {
 			if(obj instanceof ILaunchConfigurationDelegate) {
 				fDelegate = (ILaunchConfigurationDelegate)obj;
 			} else {
-				throw new CoreException(new Status(IStatus.ERROR, DebugPlugin.getUniqueIdentifier(), DebugPlugin.ERROR, MessageFormat.format(DebugCoreMessages.LaunchDelegate_3, new Object[] { getId() }), null));
+				throw new CoreException(new Status(IStatus.ERROR, DebugPlugin.getUniqueIdentifier(), DebugPlugin.ERROR, MessageFormat.format(DebugCoreMessages.LaunchDelegate_3, getId()), null));
 			}
 		}
 		return fDelegate;
@@ -179,9 +179,9 @@ public final class LaunchDelegate implements ILaunchDelegate {
 			}
 			name = name.trim();
 			if (Character.isUpperCase(name.charAt(0))) {
-				name = MessageFormat.format(DebugCoreMessages.LaunchDelegate_1, new Object[] { name });
+				name = MessageFormat.format(DebugCoreMessages.LaunchDelegate_1, name);
 			} else {
-				name = MessageFormat.format(DebugCoreMessages.LaunchDelegate_2, new Object[] { name });
+				name = MessageFormat.format(DebugCoreMessages.LaunchDelegate_2, name);
 			}
 		}
 		return name;

--- a/debug/org.eclipse.debug.core/core/org/eclipse/debug/internal/core/LaunchManager.java
+++ b/debug/org.eclipse.debug.core/core/org/eclipse/debug/internal/core/LaunchManager.java
@@ -948,8 +948,7 @@ public class LaunchManager extends PlatformObject implements ILaunchManager, IRe
 		}
 		String newName = base;
 		while (isExistingLaunchConfigurationName(newName)) {
-			newName = MessageFormat.format(DebugCoreMessages.LaunchManager_31, new Object[] {
-					base, Integer.toString(index) });
+			newName = MessageFormat.format(DebugCoreMessages.LaunchManager_31, base, Integer.toString(index));
 			index++;
 		}
 		return newName;
@@ -1247,10 +1246,9 @@ public class LaunchManager extends PlatformObject implements ILaunchManager, IRe
 				}
 
 			} else if (store != null){
-				throw createDebugException(MessageFormat.format(DebugCoreMessages.LaunchManager_does_not_exist, new Object[] {
-						config.getName(), store.toURI().toString() }), null);
+				throw createDebugException(MessageFormat.format(DebugCoreMessages.LaunchManager_does_not_exist, config.getName(), store.toURI().toString()), null);
 			} else {
-				throw createDebugException(MessageFormat.format(DebugCoreMessages.LaunchManager_does_not_exist_no_store_found, new Object[] { config.getName() }), null);
+				throw createDebugException(MessageFormat.format(DebugCoreMessages.LaunchManager_does_not_exist_no_store_found, config.getName()), null);
 			}
 		}
 		return info;
@@ -2039,7 +2037,7 @@ public class LaunchManager extends PlatformObject implements ILaunchManager, IRe
 		IConfigurationElement config = fSourceLocators.get(identifier);
 		if (config == null) {
 			throw new CoreException(new Status(IStatus.ERROR, DebugPlugin.getUniqueIdentifier(), DebugException.INTERNAL_ERROR,
- MessageFormat.format(DebugCoreMessages.LaunchManager_Source_locator_does_not_exist___0__13, new Object[] { identifier }), null));
+ MessageFormat.format(DebugCoreMessages.LaunchManager_Source_locator_does_not_exist___0__13, identifier), null));
 		}
 		IPersistableSourceLocator sourceLocator = (IPersistableSourceLocator)config.createExecutableExtension("class"); //$NON-NLS-1$
 		if (sourceLocator instanceof AbstractSourceLookupDirector) {
@@ -2299,8 +2297,7 @@ public class LaunchManager extends PlatformObject implements ILaunchManager, IRe
 			}
 		} catch (CoreException ce) {
 		}
-		throw createDebugException(MessageFormat.format(DebugCoreMessages.LaunchManager__0__occurred_while_reading_launch_configuration_file__1___1, new Object[] {
-				e.toString(), uri }), e);
+		throw createDebugException(MessageFormat.format(DebugCoreMessages.LaunchManager__0__occurred_while_reading_launch_configuration_file__1___1, e.toString(), uri), e);
 	}
 
 	/**
@@ -2407,7 +2404,7 @@ public class LaunchManager extends PlatformObject implements ILaunchManager, IRe
 			if (lmonitor.isCanceled()) {
 				break;
 			}
-			lmonitor.subTask(MessageFormat.format(DebugCoreMessages.LaunchManager_28, new Object[] { source.getName() }));
+			lmonitor.subTask(MessageFormat.format(DebugCoreMessages.LaunchManager_28, source.getName()));
 			IPath location = IPath.fromOSString(LOCAL_LAUNCH_CONFIGURATION_CONTAINER_PATH.toOSString()).append(source.getName());
 			File target = location.toFile();
 			IPath locationdir = location.removeLastSegments(1);
@@ -2521,13 +2518,13 @@ public class LaunchManager extends PlatformObject implements ILaunchManager, IRe
 		if(Platform.OS_WIN32.equals(Platform.getOS())) {
 			for (String element : UNSUPPORTED_WIN32_CONFIG_NAMES) {
 				if(configname.equals(element)) {
-					throw new IllegalArgumentException(MessageFormat.format(DebugCoreMessages.LaunchManager_invalid_config_name, new Object[] { configname }));
+					throw new IllegalArgumentException(MessageFormat.format(DebugCoreMessages.LaunchManager_invalid_config_name, configname));
 				}
 			}
 		}
 		for (char element : DISALLOWED_CONFIG_NAME_CHARS) {
 			if (configname.indexOf(element) > -1) {
-				throw new IllegalArgumentException(MessageFormat.format(DebugCoreMessages.LaunchManager_invalid_config_name_char, new Object[] { String.valueOf(element) }));
+				throw new IllegalArgumentException(MessageFormat.format(DebugCoreMessages.LaunchManager_invalid_config_name_char, String.valueOf(element)));
 			}
 		}
 		return true;

--- a/debug/org.eclipse.debug.core/core/org/eclipse/debug/internal/core/LaunchMode.java
+++ b/debug/org.eclipse.debug.core/core/org/eclipse/debug/internal/core/LaunchMode.java
@@ -71,7 +71,7 @@ public class LaunchMode implements ILaunchMode {
 	 * @throws CoreException if a problem is encountered
 	 */
 	private void missingAttribute(String attrName) throws CoreException {
-		throw new CoreException(new Status(IStatus.ERROR, DebugPlugin.getUniqueIdentifier(), DebugPlugin.ERROR, MessageFormat.format(DebugCoreMessages.LaunchMode_1, new Object[] { attrName }), null));
+		throw new CoreException(new Status(IStatus.ERROR, DebugPlugin.getUniqueIdentifier(), DebugPlugin.ERROR, MessageFormat.format(DebugCoreMessages.LaunchMode_1, attrName), null));
 	}
 
 	@Override
@@ -87,7 +87,7 @@ public class LaunchMode implements ILaunchMode {
 	public String getLaunchAsLabel() {
 		String label = fConfigurationElement.getAttribute(IConfigurationElementConstants.LAUNCH_AS_LABEL);
 		if (label == null) {
-			return MessageFormat.format(DebugCoreMessages.LaunchMode_0, new Object[] { getLabel() });
+			return MessageFormat.format(DebugCoreMessages.LaunchMode_0, getLabel());
 		}
 		return label;
 	}

--- a/debug/org.eclipse.debug.core/core/org/eclipse/debug/internal/core/LogicalStructureType.java
+++ b/debug/org.eclipse.debug.core/core/org/eclipse/debug/internal/core/LogicalStructureType.java
@@ -83,7 +83,7 @@ public class LogicalStructureType implements ILogicalStructureType, ILogicalStru
 	 * @throws CoreException if a problem is encountered
 	 */
 	private void missingAttribute(String attrName) throws CoreException {
-		throw new CoreException(new Status(IStatus.ERROR, DebugPlugin.getUniqueIdentifier(), DebugPlugin.ERROR, MessageFormat.format(DebugCoreMessages.LogicalStructureType_1, new Object[] { attrName }), null));
+		throw new CoreException(new Status(IStatus.ERROR, DebugPlugin.getUniqueIdentifier(), DebugPlugin.ERROR, MessageFormat.format(DebugCoreMessages.LogicalStructureType_1, attrName), null));
 	}
 
 	@Override

--- a/debug/org.eclipse.debug.core/core/org/eclipse/debug/internal/core/variables/ResourceResolver.java
+++ b/debug/org.eclipse.debug.core/core/org/eclipse/debug/internal/core/variables/ResourceResolver.java
@@ -53,7 +53,7 @@ public class ResourceResolver implements IDynamicVariableResolver {
 				return translateToValue(resource, variable);
 			}
 		}
-		abort(MessageFormat.format(Messages.ResourceResolver_0, new Object[] { getReferenceExpression(variable, argument) }), null);
+		abort(MessageFormat.format(Messages.ResourceResolver_0, getReferenceExpression(variable, argument)), null);
 		return null;
 	}
 
@@ -128,7 +128,7 @@ public class ResourceResolver implements IDynamicVariableResolver {
 		} catch (CoreException e) {
 			// unable to resolve a selection
 		}
-		abort(MessageFormat.format(Messages.ResourceResolver_1, new Object[] { getReferenceExpression(variable, null) }), null);
+		abort(MessageFormat.format(Messages.ResourceResolver_1, getReferenceExpression(variable, null)), null);
 		return null;
 	}
 
@@ -160,7 +160,7 @@ public class ResourceResolver implements IDynamicVariableResolver {
 		} else if (name.endsWith("_name")) { //$NON-NLS-1$
 			return resource.getName();
 		}
-		abort(MessageFormat.format(Messages.ResourceResolver_2, new Object[] { getReferenceExpression(variable, null) }), null);
+		abort(MessageFormat.format(Messages.ResourceResolver_2, getReferenceExpression(variable, null)), null);
 		return null;
 	}
 


### PR DESCRIPTION
### The following cleanups where applied:

- Add final modifier to private fields
- Add missing '<span>@</span>Deprecated' annotations
- Add missing '<span>@</span>Override' annotations
- Add missing '<span>@</span>Override' annotations to implementations of interface methods
- Convert control statement bodies to block
- Make inner classes static where possible
- Remove unnecessary array creation for varargs
- Remove unnecessary suppress warning tokens
- Replace deprecated calls with inlined content where possible
- Use pattern matching for instanceof

