### PR TITLE
Clean Code for debug/org.eclipse.debug.examples.core

### DIFF
--- a/.github/workflows/doCleanCode.yml
+++ b/.github/workflows/doCleanCode.yml
@@ -1,0 +1,17 @@
+name: Perform Code Clean
+concurrency: 
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+on:
+  workflow_dispatch:
+
+jobs:
+  clean-code:
+    uses: laeubi/eclipse.platform.releng.aggregator/.github/workflows/cleanCode.yml@limit_number_of_cleanup_prs
+    with:
+      author: Eclipse Platform Bot <platform-bot@eclipse.org>
+      do-quickfix: false
+      do-cleanups: true
+      bundle-folders: ant/*/ debug/*/ resources/bundles/*/ runtime/bundles/*/ team/bundles/*/ ua/*/ update/*/ platform/*/
+    secrets:
+      token: ${{ secrets.PLATFORM_BOT_PAT }}

--- a/debug/org.eclipse.debug.examples.core/src/org/eclipse/debug/examples/core/pda/DebugCorePlugin.java
+++ b/debug/org.eclipse.debug.examples.core/src/org/eclipse/debug/examples/core/pda/DebugCorePlugin.java
@@ -114,8 +114,9 @@ public class DebugCorePlugin extends Plugin {
 	 */
 	public ResourceBundle getResourceBundle() {
 		try {
-			if (resourceBundle == null)
+			if (resourceBundle == null) {
 				resourceBundle = ResourceBundle.getBundle("org.eclipse.debug.examples.core.pda.DebugCorePluginResources"); //$NON-NLS-1$
+			}
 		} catch (MissingResourceException x) {
 			resourceBundle = null;
 		}

--- a/debug/org.eclipse.debug.examples.core/src/org/eclipse/debug/examples/core/pda/launcher/PDALaunchDelegate.java
+++ b/debug/org.eclipse.debug.examples.core/src/org/eclipse/debug/examples/core/pda/launcher/PDALaunchDelegate.java
@@ -63,7 +63,7 @@ public class PDALaunchDelegate extends LaunchConfigurationDelegate {
 		}
 		File exe = new File(javaVMExec);
 		if (!exe.exists()) {
-			abort(MessageFormat.format("Specified java VM executable {0} does not exist.", new Object[]{javaVMExec}), null); //$NON-NLS-1$
+			abort(MessageFormat.format("Specified java VM executable {0} does not exist.", javaVMExec), null); //$NON-NLS-1$
 		}
 		commandList.add(javaVMExec);
 
@@ -80,7 +80,7 @@ public class PDALaunchDelegate extends LaunchConfigurationDelegate {
 
 		IFile file = ResourcesPlugin.getWorkspace().getRoot().getFile(IPath.fromOSString(program));
 		if (!file.exists()) {
-			abort(MessageFormat.format("Perl program {0} does not exist.", new Object[] { file.getFullPath().toString() }), null); //$NON-NLS-1$
+			abort(MessageFormat.format("Perl program {0} does not exist.", file.getFullPath().toString()), null); //$NON-NLS-1$
 		}
 
 		commandList.add(file.getLocation().toOSString());

--- a/debug/org.eclipse.debug.examples.core/src/org/eclipse/debug/examples/core/pda/model/PDAStackFrame.java
+++ b/debug/org.eclipse.debug.examples.core/src/org/eclipse/debug/examples/core/pda/model/PDAStackFrame.java
@@ -195,8 +195,7 @@ public class PDAStackFrame extends PDADebugElement implements IStackFrame {
 
 	@Override
 	public boolean equals(Object obj) {
-		if (obj instanceof PDAStackFrame) {
-			PDAStackFrame sf = (PDAStackFrame)obj;
+		if (obj instanceof PDAStackFrame sf) {
 			return sf.getThread().equals(getThread()) &&
 				sf.getSourceName().equals(getSourceName()) &&
 				sf.fId == fId;

--- a/debug/org.eclipse.debug.examples.core/src/org/eclipse/debug/examples/core/pda/model/PDAThread.java
+++ b/debug/org.eclipse.debug.examples.core/src/org/eclipse/debug/examples/core/pda/model/PDAThread.java
@@ -296,8 +296,7 @@ public class PDAThread extends PDADebugElement implements IThread, IPDAEventList
 
 	@Override
 	public void handleEvent(PDAEvent _event) {
-		if (_event instanceof PDARunControlEvent && fThreadId == ((PDARunControlEvent)_event).fThreadId) {
-			PDARunControlEvent event = (PDARunControlEvent)_event;
+		if (_event instanceof PDARunControlEvent event && fThreadId == event.fThreadId) {
 			// clear previous state
 			fBreakpoint = null;
 			setStepping(false);


### PR DESCRIPTION
### The following cleanups where applied:

- Add final modifier to private fields
- Add missing '<span>@</span>Deprecated' annotations
- Add missing '<span>@</span>Override' annotations
- Add missing '<span>@</span>Override' annotations to implementations of interface methods
- Convert control statement bodies to block
- Make inner classes static where possible
- Remove unnecessary array creation for varargs
- Remove unnecessary suppress warning tokens
- Replace deprecated calls with inlined content where possible
- Use pattern matching for instanceof

