### PR TITLE
Clean Code for debug/org.eclipse.debug.examples.memory

### DIFF
--- a/.github/workflows/doCleanCode.yml
+++ b/.github/workflows/doCleanCode.yml
@@ -1,0 +1,17 @@
+name: Perform Code Clean
+concurrency: 
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+on:
+  workflow_dispatch:
+
+jobs:
+  clean-code:
+    uses: laeubi/eclipse.platform.releng.aggregator/.github/workflows/cleanCode.yml@limit_number_of_cleanup_prs
+    with:
+      author: Eclipse Platform Bot <platform-bot@eclipse.org>
+      do-quickfix: false
+      do-cleanups: true
+      bundle-folders: ant/*/ debug/*/ resources/bundles/*/ runtime/bundles/*/ team/bundles/*/ ua/*/ update/*/ platform/*/
+    secrets:
+      token: ${{ secrets.PLATFORM_BOT_PAT }}

--- a/debug/org.eclipse.debug.examples.memory/src/org/eclipse/debug/examples/internal/memory/launchconfig/SampleModelPresentation.java
+++ b/debug/org.eclipse.debug.examples.memory/src/org/eclipse/debug/examples/internal/memory/launchconfig/SampleModelPresentation.java
@@ -92,8 +92,7 @@ public class SampleModelPresentation implements IDebugModelPresentation, IColorP
 	@Override
 	public Color getForeground(Object element) {
 
-		if (element instanceof MemoryRenderingElement) {
-			MemoryRenderingElement elm = (MemoryRenderingElement) element;
+		if (element instanceof MemoryRenderingElement elm) {
 			MemoryByte[] bytes = elm.getBytes();
 			if (!bytes[0].isWritable()) {
 				return blue;


### PR DESCRIPTION
### The following cleanups where applied:

- Add final modifier to private fields
- Add missing '<span>@</span>Deprecated' annotations
- Add missing '<span>@</span>Override' annotations
- Add missing '<span>@</span>Override' annotations to implementations of interface methods
- Convert control statement bodies to block
- Make inner classes static where possible
- Remove unnecessary array creation for varargs
- Remove unnecessary suppress warning tokens
- Replace deprecated calls with inlined content where possible
- Use pattern matching for instanceof

