### PR TITLE
Clean Code for debug/org.eclipse.debug.examples.ui

### DIFF
--- a/debug/org.eclipse.debug.examples.ui/src/org/eclipse/debug/examples/ui/midi/adapters/ControlCellModifier.java
+++ b/debug/org.eclipse.debug.examples.ui/src/org/eclipse/debug/examples/ui/midi/adapters/ControlCellModifier.java
@@ -38,8 +38,7 @@ public class ControlCellModifier implements ICellModifier {
 	@Override
 	public Object getValue(Object element, String property) {
 		if (SequencerColumnPresentation.COL_VALUE.equals(property)) {
-			if (element instanceof SequencerControl) {
-				SequencerControl control = (SequencerControl) element;
+			if (element instanceof SequencerControl control) {
 				return control.getValue();
 			}
 		}
@@ -51,9 +50,8 @@ public class ControlCellModifier implements ICellModifier {
 		Object oldValue = getValue(element, property);
 		if (!value.equals(oldValue)) {
 			if (SequencerColumnPresentation.COL_VALUE.equals(property)) {
-				if (element instanceof SequencerControl) {
+				if (element instanceof SequencerControl control) {
 					if (value instanceof String) {
-						SequencerControl control = (SequencerControl) element;
 						control.setValue((String) value);
 					}
 				}

--- a/debug/org.eclipse.debug.examples.ui/src/org/eclipse/debug/examples/ui/midi/adapters/MidiEventLabelProvider.java
+++ b/debug/org.eclipse.debug.examples.ui/src/org/eclipse/debug/examples/ui/midi/adapters/MidiEventLabelProvider.java
@@ -45,8 +45,7 @@ public class MidiEventLabelProvider extends ElementLabelProvider {
 			}
 			return buffer.toString();
 		} else if (TrackColumnPresentation.COL_COMMAND.equals(columnId)) {
-			if (message instanceof ShortMessage) {
-				ShortMessage sm = (ShortMessage) message;
+			if (message instanceof ShortMessage sm) {
 				StringBuilder buf = new StringBuilder();
 				appendByte(buf, (byte)sm.getCommand());
 				return buf.toString();

--- a/debug/org.eclipse.debug.examples.ui/src/org/eclipse/debug/examples/ui/midi/launcher/MidiLaunchShortcut.java
+++ b/debug/org.eclipse.debug.examples.ui/src/org/eclipse/debug/examples/ui/midi/launcher/MidiLaunchShortcut.java
@@ -44,12 +44,10 @@ public class MidiLaunchShortcut implements ILaunchShortcut {
 
 	@Override
 	public void launch(ISelection selection, String mode) {
-		if (selection instanceof IStructuredSelection) {
-			IStructuredSelection ss = (IStructuredSelection) selection;
+		if (selection instanceof IStructuredSelection ss) {
 			if (ss.size() == 1) {
 				Object element = ss.getFirstElement();
-				if (element instanceof IFile) {
-					IFile file = (IFile) element;
+				if (element instanceof IFile file) {
 					ILaunchConfiguration configuration = getConfiguration(file);
 					if (configuration != null) {
 						DebugUITools.launch(configuration, mode);

--- a/debug/org.eclipse.debug.examples.ui/src/org/eclipse/debug/examples/ui/midi/launcher/MidiTabGroup.java
+++ b/debug/org.eclipse.debug.examples.ui/src/org/eclipse/debug/examples/ui/midi/launcher/MidiTabGroup.java
@@ -26,9 +26,6 @@ import org.eclipse.debug.ui.ILaunchConfigurationTab;
 public class MidiTabGroup extends AbstractLaunchConfigurationTabGroup {
 	@Override
 	public void createTabs(ILaunchConfigurationDialog dialog, String mode) {
-		setTabs(new ILaunchConfigurationTab[] {
-				new MidiMainTab(),
-				new CommonTab()
-		});
+		setTabs(new MidiMainTab(), new CommonTab());
 	}
 }

--- a/debug/org.eclipse.debug.examples.ui/src/org/eclipse/debug/examples/ui/pda/adapters/AddPDAMemoryBlockAction.java
+++ b/debug/org.eclipse.debug.examples.ui/src/org/eclipse/debug/examples/ui/pda/adapters/AddPDAMemoryBlockAction.java
@@ -59,8 +59,7 @@ public class AddPDAMemoryBlockAction implements IActionDelegate2{
 	 * @return debug target from the selection or <code>null</code>
 	 */
 	private PDADebugTarget getTarget(ISelection selection) {
-		if (selection instanceof IStructuredSelection) {
-			IStructuredSelection ss = (IStructuredSelection) selection;
+		if (selection instanceof IStructuredSelection ss) {
 			if (ss.size() == 1) {
 				Object element = ss.getFirstElement();
 				if (element instanceof PDADebugTarget) {

--- a/debug/org.eclipse.debug.examples.ui/src/org/eclipse/debug/examples/ui/pda/breakpoints/PDABreakpointAdapter.java
+++ b/debug/org.eclipse.debug.examples.ui/src/org/eclipse/debug/examples/ui/pda/breakpoints/PDABreakpointAdapter.java
@@ -76,8 +76,7 @@ public class PDABreakpointAdapter implements IToggleBreakpointsTargetExtension {
 	 * given part, or <code>null</code> if none
 	 */
 	private ITextEditor getEditor(IWorkbenchPart part) {
-		if (part instanceof ITextEditor) {
-			ITextEditor editorPart = (ITextEditor) part;
+		if (part instanceof ITextEditor editorPart) {
 			IResource resource = editorPart.getEditorInput().getAdapter(IResource.class);
 			if (resource != null) {
 				String extension = resource.getFileExtension();
@@ -101,8 +100,7 @@ public class PDABreakpointAdapter implements IToggleBreakpointsTargetExtension {
 	@Override
 	public void toggleWatchpoints(IWorkbenchPart part, ISelection selection) throws CoreException {
 		String[] variableAndFunctionName = getVariableAndFunctionName(part, selection);
-		if (variableAndFunctionName != null && part instanceof ITextEditor && selection instanceof ITextSelection) {
-			ITextEditor editorPart = (ITextEditor)part;
+		if (variableAndFunctionName != null && part instanceof ITextEditor editorPart && selection instanceof ITextSelection) {
 			int lineNumber = ((ITextSelection)selection).getStartLine();
 			IResource resource = editorPart.getEditorInput().getAdapter(IResource.class);
 			String var = variableAndFunctionName[0];
@@ -123,8 +121,7 @@ public class PDABreakpointAdapter implements IToggleBreakpointsTargetExtension {
 		IBreakpoint[] breakpoints = DebugPlugin.getDefault().getBreakpointManager().getBreakpoints(DebugCorePlugin.ID_PDA_DEBUG_MODEL);
 		for (int i = 0; i < breakpoints.length; i++) {
 			IBreakpoint breakpoint = breakpoints[i];
-			if (breakpoint instanceof PDAWatchpoint && resource.equals(breakpoint.getMarker().getResource())) {
-				PDAWatchpoint watchpoint = (PDAWatchpoint)breakpoint;
+			if (breakpoint instanceof PDAWatchpoint watchpoint && resource.equals(breakpoint.getMarker().getResource())) {
 				String otherVar = watchpoint.getVariableName();
 				String otherFcn = watchpoint.getFunctionName();
 				if (otherVar.equals(var) && otherFcn.equals(fcn)) {
@@ -148,8 +145,7 @@ public class PDABreakpointAdapter implements IToggleBreakpointsTargetExtension {
 	 */
 	protected String[] getVariableAndFunctionName(IWorkbenchPart part, ISelection selection) {
 		ITextEditor editor = getEditor(part);
-		if (editor != null && selection instanceof ITextSelection) {
-			ITextSelection textSelection = (ITextSelection) selection;
+		if (editor != null && selection instanceof ITextSelection textSelection) {
 			IDocumentProvider documentProvider = editor.getDocumentProvider();
 			try {
 				documentProvider.connect(this);

--- a/debug/org.eclipse.debug.examples.ui/src/org/eclipse/debug/examples/ui/pda/breakpoints/PDAToggleWatchpointsTarget.java
+++ b/debug/org.eclipse.debug.examples.ui/src/org/eclipse/debug/examples/ui/pda/breakpoints/PDAToggleWatchpointsTarget.java
@@ -54,8 +54,7 @@ public class PDAToggleWatchpointsTarget extends PDABreakpointAdapter {
 	public boolean canToggleWatchpoints(IWorkbenchPart part, ISelection selection) {
 		if (super.canToggleWatchpoints(part, selection)) {
 			return true;
-		} else if (selection instanceof IStructuredSelection) {
-			IStructuredSelection ss = (IStructuredSelection)selection;
+		} else if (selection instanceof IStructuredSelection ss) {
 			return ss.getFirstElement() instanceof PDAVariable;
 		}
 		return false;
@@ -65,10 +64,9 @@ public class PDAToggleWatchpointsTarget extends PDABreakpointAdapter {
 	public void toggleWatchpoints(IWorkbenchPart part, ISelection selection) throws CoreException {
 		String[] variableAndFunctionName = getVariableAndFunctionName(part, selection);
 
-		if (variableAndFunctionName != null && part instanceof ITextEditor && selection instanceof ITextSelection) {
+		if (variableAndFunctionName != null && part instanceof ITextEditor editorPart && selection instanceof ITextSelection) {
 			// Selection inside text editor.  Create a watchpoint based on
 			// current source line.
-			ITextEditor editorPart = (ITextEditor)part;
 			int lineNumber = ((ITextSelection)selection).getStartLine();
 			IResource resource = editorPart.getEditorInput().getAdapter(IResource.class);
 			String var = variableAndFunctionName[0];

--- a/debug/org.eclipse.debug.examples.ui/src/org/eclipse/debug/examples/ui/pda/editor/PDAScanner.java
+++ b/debug/org.eclipse.debug.examples.ui/src/org/eclipse/debug/examples/ui/pda/editor/PDAScanner.java
@@ -82,6 +82,6 @@ public class PDAScanner extends BufferedRuleBasedScanner {
 		// labels
 		token = new Token(new TextAttribute(DebugUIPlugin.getDefault().getColor(DebugUIPlugin.LABEL)));
 		WordRule labels = new WordRule(new PDALabelDetector(), token);
-		setRules(new IRule[]{keywords, labels});
+		setRules(keywords, labels);
 	}
 }

--- a/debug/org.eclipse.debug.examples.ui/src/org/eclipse/debug/examples/ui/pda/editor/PopFrameActionDelegate.java
+++ b/debug/org.eclipse.debug.examples.ui/src/org/eclipse/debug/examples/ui/pda/editor/PopFrameActionDelegate.java
@@ -49,11 +49,9 @@ public class PopFrameActionDelegate implements IObjectActionDelegate, IActionDel
 
 	@Override
 	public void selectionChanged(IAction action, ISelection selection) {
-		if (selection instanceof IStructuredSelection) {
-			IStructuredSelection ss = (IStructuredSelection) selection;
+		if (selection instanceof IStructuredSelection ss) {
 			Object element = ss.getFirstElement();
-			if (element instanceof PDAStackFrame) {
-				PDAStackFrame frame = (PDAStackFrame) element;
+			if (element instanceof PDAStackFrame frame) {
 				//#ifdef ex5
 //#				// TODO: Exercise 5 - enable the action if the frame's thread supports it
 				//#else

--- a/debug/org.eclipse.debug.examples.ui/src/org/eclipse/debug/examples/ui/pda/editor/TextHover.java
+++ b/debug/org.eclipse.debug.examples.ui/src/org/eclipse/debug/examples/ui/pda/editor/TextHover.java
@@ -49,15 +49,13 @@ public class TextHover implements ITextHover {
 		IAdaptable debugContext = DebugUITools.getDebugContext();
 		if (debugContext instanceof PDAStackFrame) {
 			frame = (PDAStackFrame) debugContext;
-		} else if (debugContext instanceof PDAThread) {
-			PDAThread thread = (PDAThread) debugContext;
+		} else if (debugContext instanceof PDAThread thread) {
 			try {
 				frame = (PDAStackFrame) thread.getTopStackFrame();
 			} catch (DebugException e) {
 				return null;
 			}
-		} else if (debugContext instanceof PDADebugTarget) {
-			PDADebugTarget target = (PDADebugTarget) debugContext;
+		} else if (debugContext instanceof PDADebugTarget target) {
 			try {
 				IThread[] threads = target.getThreads();
 				if (threads.length > 0) {

--- a/debug/org.eclipse.debug.examples.ui/src/org/eclipse/debug/examples/ui/pda/editor/WordFinder.java
+++ b/debug/org.eclipse.debug.examples.ui/src/org/eclipse/debug/examples/ui/pda/editor/WordFinder.java
@@ -46,8 +46,9 @@ public class WordFinder {
 
 			while (pos >= 0) {
 				c= document.getChar(pos);
-				if (!Character.isJavaIdentifierPart(c))
+				if (!Character.isJavaIdentifierPart(c)) {
 					break;
+				}
 				--pos;
 			}
 
@@ -58,8 +59,9 @@ public class WordFinder {
 
 			while (pos < length) {
 				c= document.getChar(pos);
-				if (!Character.isJavaIdentifierPart(c))
+				if (!Character.isJavaIdentifierPart(c)) {
 					break;
+				}
 				++pos;
 			}
 
@@ -69,12 +71,13 @@ public class WordFinder {
 		}
 
 		if (start > -1 && end > -1) {
-			if (start == offset && end == offset)
+			if (start == offset && end == offset) {
 				return new Region(offset, 0);
-			else if (start == offset)
+			} else if (start == offset) {
 				return new Region(start, end - start);
-			else
+			} else {
 				return new Region(start + 1, end - start - 1);
+			}
 		}
 
 		return null;

--- a/debug/org.eclipse.debug.examples.ui/src/org/eclipse/debug/examples/ui/pda/launcher/PDATabGroup.java
+++ b/debug/org.eclipse.debug.examples.ui/src/org/eclipse/debug/examples/ui/pda/launcher/PDATabGroup.java
@@ -30,11 +30,7 @@ public class PDATabGroup extends AbstractLaunchConfigurationTabGroup {
 //#		// TODO: Exercise 1 - add the PDA main tab, source lookup tab and common
 //#		//  tab to the tab group
 		//#else
-		setTabs(new ILaunchConfigurationTab[] {
-				new PDAMainTab(),
-				new SourceLookupTab(),
-				new CommonTab()
-		});
+		setTabs(new PDAMainTab(), new SourceLookupTab(), new CommonTab());
 		//#endif
 	}
 }

--- a/debug/org.eclipse.debug.examples.ui/src/org/eclipse/debug/examples/ui/pda/presentation/PDAModelPresentation.java
+++ b/debug/org.eclipse.debug.examples.ui/src/org/eclipse/debug/examples/ui/pda/presentation/PDAModelPresentation.java
@@ -133,8 +133,7 @@ public class PDAModelPresentation extends LabelProvider implements IDebugModelPr
 				}
 			} else {
 				IBreakpoint breakpoint = breakpoints[0]; // there can only be one in PDA
-				if (breakpoint instanceof PDALineBreakpoint) {
-					PDALineBreakpoint pdaBreakpoint = (PDALineBreakpoint) breakpoint;
+				if (breakpoint instanceof PDALineBreakpoint pdaBreakpoint) {
 					if (pdaBreakpoint instanceof PDAWatchpoint) {
 						try {
 							PDAWatchpoint watchpoint = (PDAWatchpoint)pdaBreakpoint;

--- a/debug/org.eclipse.debug.examples.ui/src/org/eclipse/debug/examples/ui/pda/views/AbstractDataStackViewHandler.java
+++ b/debug/org.eclipse.debug.examples.ui/src/org/eclipse/debug/examples/ui/pda/views/AbstractDataStackViewHandler.java
@@ -33,9 +33,7 @@ abstract public class AbstractDataStackViewHandler extends AbstractHandler {
 	@Override
 	public Object execute(ExecutionEvent event) throws ExecutionException {
 		IWorkbenchPart part = HandlerUtil.getActivePartChecked(event);
-		if (part instanceof DataStackView) {
-			DataStackView view = (DataStackView)part;
-
+		if (part instanceof DataStackView view) {
 			ISelection selection = DebugUITools.getDebugContextForEventChecked(event);
 			if (selection instanceof IStructuredSelection) {
 				Object element = ((IStructuredSelection)selection).getFirstElement();

--- a/debug/org.eclipse.debug.examples.ui/src/org/eclipse/debug/examples/ui/pda/views/PopHandler.java
+++ b/debug/org.eclipse.debug.examples.ui/src/org/eclipse/debug/examples/ui/pda/views/PopHandler.java
@@ -34,8 +34,8 @@ public class PopHandler extends AbstractDataStackViewHandler {
 	@Override
 	protected void doExecute(DataStackView view, PDAThread thread, ISelection selection) throws ExecutionException {
 		TreeViewer viewer = (TreeViewer)view.getViewer();
-		Object popee = selection instanceof IStructuredSelection
-			? ((IStructuredSelection)selection).getFirstElement() : null;
+		Object popee = selection instanceof IStructuredSelection i2
+			? i2.getFirstElement() : null;
 		if (popee != null) {
 			try {
 				IValue[] stack = thread.getDataStack();


### PR DESCRIPTION
### The following cleanups where applied:

- Add final modifier to private fields
- Add missing '<span>@</span>Deprecated' annotations
- Add missing '<span>@</span>Override' annotations
- Add missing '<span>@</span>Override' annotations to implementations of interface methods
- Convert control statement bodies to block
- Make inner classes static where possible
- Remove unnecessary array creation for varargs
- Remove unnecessary suppress warning tokens
- Replace deprecated calls with inlined content where possible
- Use pattern matching for instanceof

