### PR TITLE
Clean Code for debug/org.eclipse.debug.tests

### DIFF
--- a/.github/workflows/cc2.yml
+++ b/.github/workflows/cc2.yml
@@ -1,0 +1,17 @@
+name: Perform Code Clean 2
+concurrency: 
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+on:
+  workflow_dispatch:
+
+jobs:
+  clean-code:
+    uses: laeubi/eclipse.platform.releng.aggregator/.github/workflows/cleanCode.yml@limit_number_of_cleanup_prs
+    with:
+      author: Eclipse Platform Bot <platform-bot@eclipse.org>
+      do-quickfix: false
+      do-cleanups: true
+      bundle-folders: ant/*/ debug/*/ resources/bundles/*/ runtime/bundles/*/ team/bundles/*/ ua/*/ update/*/ platform/*/
+    secrets:
+      token: ${{ secrets.PLATFORM_BOT_PAT }}

--- a/.github/workflows/cc3.yml
+++ b/.github/workflows/cc3.yml
@@ -1,0 +1,17 @@
+name: Perform Code Clean 3
+concurrency: 
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+on:
+  workflow_dispatch:
+
+jobs:
+  clean-code:
+    uses: laeubi/eclipse.platform.releng.aggregator/.github/workflows/cleanCode.yml@limit_number_of_cleanup_prs
+    with:
+      author: Eclipse Platform Bot <platform-bot@eclipse.org>
+      do-quickfix: false
+      do-cleanups: true
+      bundle-folders: ant/*/ debug/*/ resources/bundles/*/ runtime/bundles/*/ team/bundles/*/ ua/*/ update/*/ platform/*/
+    secrets:
+      token: ${{ secrets.PLATFORM_BOT_PAT }}

--- a/.github/workflows/cc4.yml
+++ b/.github/workflows/cc4.yml
@@ -1,0 +1,17 @@
+name: Perform Code Clean 4
+concurrency: 
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+on:
+  workflow_dispatch:
+
+jobs:
+  clean-code:
+    uses: laeubi/eclipse.platform.releng.aggregator/.github/workflows/cleanCode.yml@limit_number_of_cleanup_prs
+    with:
+      author: Eclipse Platform Bot <platform-bot@eclipse.org>
+      do-quickfix: false
+      do-cleanups: true
+      bundle-folders: ant/*/ debug/*/ resources/bundles/*/ runtime/bundles/*/ team/bundles/*/ ua/*/ update/*/ platform/*/
+    secrets:
+      token: ${{ secrets.PLATFORM_BOT_PAT }}

--- a/.github/workflows/doCleanCode.yml
+++ b/.github/workflows/doCleanCode.yml
@@ -1,0 +1,17 @@
+name: Perform Code Clean
+concurrency: 
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+on:
+  workflow_dispatch:
+
+jobs:
+  clean-code:
+    uses: laeubi/eclipse.platform.releng.aggregator/.github/workflows/cleanCode.yml@limit_number_of_cleanup_prs
+    with:
+      author: Eclipse Platform Bot <platform-bot@eclipse.org>
+      do-quickfix: false
+      do-cleanups: true
+      bundle-folders: ant/*/ debug/*/ resources/bundles/*/ runtime/bundles/*/ team/bundles/*/ ua/*/ update/*/ platform/*/
+    secrets:
+      token: ${{ secrets.PLATFORM_BOT_PAT }}

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/breakpoint/SerialExecutorTest.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/breakpoint/SerialExecutorTest.java
@@ -26,7 +26,6 @@ import org.eclipse.debug.internal.ui.model.elements.SerialExecutor;
 import org.eclipse.debug.tests.AbstractDebugTest;
 import org.junit.Test;
 
-@SuppressWarnings("restriction")
 public class SerialExecutorTest extends AbstractDebugTest {
 	@Override
 	public void tearDown() throws Exception {

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/console/ConsoleDocumentAdapterTests.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/console/ConsoleDocumentAdapterTests.java
@@ -46,7 +46,6 @@ import org.junit.Test;
  * Primary tests fixed width mode and calculation of {@link TextChangingEvent}s.
  * </p>
  */
-@SuppressWarnings("restriction")
 public class ConsoleDocumentAdapterTests extends AbstractDebugTest {
 
 	/**

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/console/IOConsoleTestUtil.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/console/IOConsoleTestUtil.java
@@ -786,7 +786,6 @@ public final class IOConsoleTestUtil {
 	 *
 	 * @return output partition identifier
 	 */
-	@SuppressWarnings("restriction")
 	public static String outputPartitionType() {
 		return org.eclipse.ui.internal.console.IOConsolePartition.OUTPUT_PARTITION_TYPE;
 	}
@@ -797,7 +796,6 @@ public final class IOConsoleTestUtil {
 	 *
 	 * @return input partition identifier
 	 */
-	@SuppressWarnings("restriction")
 	public static String inputPartitionType() {
 		return org.eclipse.ui.internal.console.IOConsolePartition.INPUT_PARTITION_TYPE;
 	}

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/console/ProcessConsoleManagerTests.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/console/ProcessConsoleManagerTests.java
@@ -45,7 +45,6 @@ import org.junit.Test;
 /**
  * Tests the ProcessConsoleManager.
  */
-@SuppressWarnings("restriction")
 public class ProcessConsoleManagerTests extends AbstractDebugTest {
 
 	/**

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/console/ProcessConsoleTests.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/console/ProcessConsoleTests.java
@@ -192,7 +192,6 @@ public class ProcessConsoleTests extends AbstractDebugTest {
 			final ILaunch launch = new Launch(null, ILaunchManager.RUN_MODE, null);
 			launch.setAttribute(DebugPlugin.ATTR_CONSOLE_ENCODING, StandardCharsets.UTF_8.toString());
 			final IProcess process = DebugPlugin.newProcess(launch, mockProcess, "testUtf8Input");
-			@SuppressWarnings("restriction")
 			final org.eclipse.debug.internal.ui.views.console.ProcessConsole console = new org.eclipse.debug.internal.ui.views.console.ProcessConsole(process, new ConsoleColorProvider(), StandardCharsets.UTF_8.toString());
 			try {
 				console.initialize();
@@ -223,11 +222,9 @@ public class ProcessConsoleTests extends AbstractDebugTest {
 		final MockProcess mockProcess = new MockProcess(MockProcess.RUN_FOREVER);
 		try {
 			final IProcess process = mockProcess.toRuntimeProcess("testInputReadJobCancel");
-			@SuppressWarnings("restriction")
 			final org.eclipse.debug.internal.ui.views.console.ProcessConsole console = new org.eclipse.debug.internal.ui.views.console.ProcessConsole(process, new ConsoleColorProvider());
 			try {
 				console.initialize();
-				@SuppressWarnings("restriction")
 				final Class<?> jobFamily = org.eclipse.debug.internal.ui.views.console.ProcessConsole.class;
 				assertThat(Job.getJobManager().find(jobFamily)).as("check input read job started").hasSizeGreaterThan(0);
 				Job.getJobManager().cancel(jobFamily);
@@ -287,7 +284,6 @@ public class ProcessConsoleTests extends AbstractDebugTest {
 		final AtomicBoolean terminationSignaled = new AtomicBoolean(false);
 		final Process mockProcess = new MockProcess(null, null, terminateBeforeConsoleInitialization ? 0 : -1);
 		final IProcess process = DebugPlugin.newProcess(new Launch(launchConfig, ILaunchManager.RUN_MODE, null), mockProcess, name.getMethodName());
-		@SuppressWarnings("restriction")
 		final org.eclipse.debug.internal.ui.views.console.ProcessConsole console = new org.eclipse.debug.internal.ui.views.console.ProcessConsole(process, new ConsoleColorProvider());
 		console.addPropertyChangeListener(event -> {
 				if (event.getSource() == console && IConsoleConstants.P_CONSOLE_OUTPUT_COMPLETE.equals(event.getProperty())) {
@@ -389,7 +385,6 @@ public class ProcessConsoleTests extends AbstractDebugTest {
 		final IProcess process = mockProcess.toRuntimeProcess("Output Redirect", launchConfigAttributes);
 		final String encoding = launchConfigAttributes != null ? (String) launchConfigAttributes.get(DebugPlugin.ATTR_CONSOLE_ENCODING) : null;
 		final AtomicBoolean consoleFinished = new AtomicBoolean(false);
-		@SuppressWarnings("restriction")
 		final org.eclipse.debug.internal.ui.views.console.ProcessConsole console = new org.eclipse.debug.internal.ui.views.console.ProcessConsole(process, new ConsoleColorProvider(), encoding);
 		console.addPropertyChangeListener((PropertyChangeEvent event) -> {
 			if (event.getSource() == console && IConsoleConstants.P_CONSOLE_OUTPUT_COMPLETE.equals(event.getProperty())) {
@@ -409,9 +404,7 @@ public class ProcessConsoleTests extends AbstractDebugTest {
 			final IDocument doc = console.getDocument();
 
 			if (outFile != null) {
-				@SuppressWarnings("restriction")
-				String expectedPathMsg = MessageFormat.format(org.eclipse.debug.internal.ui.views.console.ConsoleMessages.ProcessConsole_1, new Object[] {
-						outFile.getAbsolutePath() });
+				String expectedPathMsg = MessageFormat.format(org.eclipse.debug.internal.ui.views.console.ConsoleMessages.ProcessConsole_1, outFile.getAbsolutePath());
 				assertEquals("No or wrong output of redirect file path in console.", expectedPathMsg, doc.get(doc.getLineOffset(0), doc.getLineLength(0)));
 				assertThat(console.getHyperlinks()).as("check redirect file path is linked").hasSize(1);
 			}
@@ -450,7 +443,6 @@ public class ProcessConsoleTests extends AbstractDebugTest {
 				launchConfigAttributes.put(DebugPlugin.ATTR_CONSOLE_ENCODING, consoleEncoding);
 				final IProcess process = mockProcess.toRuntimeProcess("simpleOutput", launchConfigAttributes);
 				sysout.println(lines[1]);
-				@SuppressWarnings("restriction")
 				final org.eclipse.debug.internal.ui.views.console.ProcessConsole console = new org.eclipse.debug.internal.ui.views.console.ProcessConsole(process, new ConsoleColorProvider(), consoleEncoding);
 				sysout.println(lines[2]);
 				try {
@@ -507,7 +499,6 @@ public class ProcessConsoleTests extends AbstractDebugTest {
 			launchConfigAttributes.put(IDebugUIConstants.ATTR_CAPTURE_IN_FILE, outFile.getCanonicalPath());
 			launchConfigAttributes.put(IDebugUIConstants.ATTR_CAPTURE_IN_CONSOLE, false);
 			final IProcess process = mockProcess.toRuntimeProcess("redirectBinaryOutput", launchConfigAttributes);
-			@SuppressWarnings("restriction")
 			final org.eclipse.debug.internal.ui.views.console.ProcessConsole console = new org.eclipse.debug.internal.ui.views.console.ProcessConsole(process, new ConsoleColorProvider(), consoleEncoding);
 			try {
 				console.initialize();
@@ -562,7 +553,6 @@ public class ProcessConsoleTests extends AbstractDebugTest {
 			launchConfigAttributes.put(IDebugUIConstants.ATTR_CAPTURE_STDIN_FILE, inFile.getCanonicalPath());
 			launchConfigAttributes.put(IDebugUIConstants.ATTR_CAPTURE_IN_CONSOLE, false);
 			final IProcess process = mockProcess.toRuntimeProcess("redirectBinaryInput", launchConfigAttributes);
-			@SuppressWarnings("restriction")
 			final org.eclipse.debug.internal.ui.views.console.ProcessConsole console = new org.eclipse.debug.internal.ui.views.console.ProcessConsole(process, new ConsoleColorProvider(), consoleEncoding);
 			try {
 				console.initialize();

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/launching/LaunchConfigurationTests.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/launching/LaunchConfigurationTests.java
@@ -86,7 +86,7 @@ import org.osgi.service.prefs.Preferences;
 @SuppressWarnings("deprecation")
 public class LaunchConfigurationTests extends AbstractLaunchTest implements ILaunchConfigurationListener {
 
-	@SuppressWarnings({ "restriction", "unused" })
+	@SuppressWarnings({ "unused" })
 	// Only ensures org.eclipse.ui.externaltools is required
 	private static final org.eclipse.ui.externaltools.internal.model.BuilderUtils ref = null;
 

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/launching/LaunchManagerTests.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/launching/LaunchManagerTests.java
@@ -545,7 +545,7 @@ public class LaunchManagerTests extends AbstractLaunchTest {
 	}
 
 	class LogListener implements ILogListener {
-		private Map<String, IStatus> logs = new HashMap<>();
+		private final Map<String, IStatus> logs = new HashMap<>();
 
 		@Override
 		public synchronized void logging(IStatus status, String plugin) {

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/logicalstructure/TestLogicalStructureTypeDelegate.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/logicalstructure/TestLogicalStructureTypeDelegate.java
@@ -9,8 +9,7 @@ public class TestLogicalStructureTypeDelegate implements ILogicalStructureTypeDe
 
 	@Override
 	public boolean providesLogicalStructure(IValue value) {
-		if (value instanceof TestValue) {
-			TestValue testValue = (TestValue) value;
+		if (value instanceof TestValue testValue) {
 			return "raw".equals(testValue.getValueString());
 		}
 		return false;

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/sourcelookup/TestSourceDirector.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/sourcelookup/TestSourceDirector.java
@@ -23,8 +23,7 @@ public class TestSourceDirector extends AbstractSourceLookupDirector {
 	public Object getSourceElement(Object element) {
 		if (element instanceof String) {
 			return element.toString() + System.currentTimeMillis();
-		} else if (element instanceof IStackFrame) {
-			IStackFrame frame = (IStackFrame) element;
+		} else if (element instanceof IStackFrame frame) {
 			return frame.getModelIdentifier() + System.currentTimeMillis();
 		}
 		return super.getSourceElement(element);

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/ui/SpyTabGroup.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/ui/SpyTabGroup.java
@@ -21,7 +21,7 @@ public class SpyTabGroup extends AbstractLaunchConfigurationTabGroup {
 
 	@Override
 	public void createTabs(ILaunchConfigurationDialog dialog, String mode) {
-		setTabs(new ILaunchConfigurationTab[] { new SpyTabA(), new SpyTabB() });
+		setTabs(new SpyTabA(), new SpyTabB());
 	}
 
 }

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/view/memory/TableRenderingTests.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/view/memory/TableRenderingTests.java
@@ -32,7 +32,6 @@ import org.junit.Test;
  * Tests for translation of memory bytes between in-memory representation and UI
  * presentation
  */
-@SuppressWarnings("restriction")
 public class TableRenderingTests {
 
 	private static final byte[] BYTES_1 = new byte[] { (byte) 0x87 };

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/viewer/model/FilterTests.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/viewer/model/FilterTests.java
@@ -60,8 +60,7 @@ abstract public class FilterTests extends AbstractViewerModelTest implements ITe
 
 		 @Override
 		public boolean select(Viewer viewer, Object parentElement, Object element) {
-			if (element instanceof TestElement) {
-				TestElement te = (TestElement)element;
+			if (element instanceof TestElement te) {
 				return !fPattern.matcher(te.getLabel()).find();
 			}
 
@@ -88,8 +87,7 @@ abstract public class FilterTests extends AbstractViewerModelTest implements ITe
 
 		 @Override
 		public boolean select(Viewer viewer, Object parentElement, Object element) {
-			if (element instanceof TestElement) {
-				TestElement te = (TestElement)element;
+			if (element instanceof TestElement te) {
 				return !fPattern.matcher(te.getLabel()).find();
 			}
 

--- a/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/viewer/model/TreeModelViewerAutopopulateAgent.java
+++ b/debug/org.eclipse.debug.tests/src/org/eclipse/debug/tests/viewer/model/TreeModelViewerAutopopulateAgent.java
@@ -79,8 +79,7 @@ public class TreeModelViewerAutopopulateAgent implements IViewerUpdateListener {
 	}
 
 	private TreePath getTreePath(Widget w) {
-		if (w instanceof TreeItem) {
-			TreeItem item = (TreeItem)w;
+		if (w instanceof TreeItem item) {
 			LinkedList<Object> segments = new LinkedList<>();
 			while (item != null) {
 				Object segment = item.getData();


### PR DESCRIPTION
### The following cleanups where applied:

- Add final modifier to private fields
- Add missing '<span>@</span>Deprecated' annotations
- Add missing '<span>@</span>Override' annotations
- Add missing '<span>@</span>Override' annotations to implementations of interface methods
- Convert control statement bodies to block
- Make inner classes static where possible
- Remove unnecessary array creation for varargs
- Remove unnecessary suppress warning tokens
- Replace deprecated calls with inlined content where possible
- Use pattern matching for instanceof

